### PR TITLE
Add tests for basic endpoints

### DIFF
--- a/tests/V2/AccountEndpointTest.php
+++ b/tests/V2/AccountEndpointTest.php
@@ -1,0 +1,19 @@
+<?php
+
+class AccountEndpointTest extends TestCase {
+    public function test() {
+        $this->mockResponse('{
+            "id":"account-guid",
+            "name"   : "Lawton.1234",
+            "world"  : 1007,
+            "guilds" : [
+                "DA9137CD-3A86-E411-B57A-00224D566B58",
+                "1F5F70AA-1DB6-E411-A2C4-00224D566B58",
+                "8B211747-3B86-E411-B57A-00224D566B58"
+            ]
+        }');
+
+        $account = $this->api()->account('api_key')->info();
+        $this->assertEquals( 'Lawton.1234', $account->name );
+    }
+}

--- a/tests/V2/CharacterEndpointTest.php
+++ b/tests/V2/CharacterEndpointTest.php
@@ -1,0 +1,23 @@
+<?php
+
+class CharacterEndpointTest extends TestCase {
+    public function testIds() {
+        $this->mockResponse('["Hello"]');
+
+        $this->assertEquals( ['Hello'], $this->api()->characters('api_key')->ids() );
+    }
+
+    public function testGet() {
+        $this->mockResponse('{
+            "name": "Hello",
+            "race": "Human",
+            "gender": "Female",
+            "profession": "Thief",
+            "level": 80,
+            "guild": "1F5F70AA-1DB6-E411-A2C4-00224D566B58"
+        }');
+
+        $character = $this->api()->characters('api_key')->get('Hello');
+        $this->assertEquals( 80, $character->level );
+    }
+}

--- a/tests/V2/ColorEndpointTest.php
+++ b/tests/V2/ColorEndpointTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class ColorEndpointTest extends TestCase {
+    public function testIds() {
+        $this->mockResponse('[1,2,3,4,5,6,7,8,9,10]');
+
+        $this->assertCount( 10, $this->api()->colors()->ids() );
+    }
+}

--- a/tests/V2/FileEndpointTest.php
+++ b/tests/V2/FileEndpointTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class FileEndpointTest extends TestCase {
+    public function testIds() {
+        $this->mockResponse('["map_complete","map_dungeon","map_heart_empty","map_heart_full"]');
+
+        $this->assertContains( 'map_heart_empty', $this->api()->files()->ids() );
+    }
+}

--- a/tests/V2/ItemEndpointTest.php
+++ b/tests/V2/ItemEndpointTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class ItemEndpointTest extends TestCase {
+    public function testIds() {
+        $this->mockResponse('[1,2,6,11,24,56,57,58,59]');
+
+        $this->assertEquals( [1,2,6,11,24,56,57,58,59], $this->api()->items()->ids() );
+    }
+}

--- a/tests/V2/MapEndpointTest.php
+++ b/tests/V2/MapEndpointTest.php
@@ -1,0 +1,22 @@
+<?php
+
+class MapEndpointTest extends TestCase {
+    public function test() {
+        $this->mockResponse('{
+            "id": 15,
+            "name": "Queensdale",
+            "min_level": 1,
+            "max_level": 15,
+            "default_floor": 1,
+            "floors": [0,1,2],
+            "region_id": 4,
+            "region_name": "Kryta",
+            "continent_id": 1,
+            "continent_name": "Tyria",
+            "map_rect": [[-43008,-27648],[43008,30720]],
+            "continent_rect": [[9856,11648],[13440,14080]]
+        }');
+
+        $this->assertEquals( 'Queensdale', $this->api()->maps()->get(15)->name );
+    }
+}

--- a/tests/V2/QuagganEndpointTest.php
+++ b/tests/V2/QuagganEndpointTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class QuagganEndpointTest extends TestCase {
+    public function test() {
+        $this->mockResponse('{"id":"cheer","url":"https://static.staticwars.com/quaggans/cheer.jpg"}');
+
+        $this->assertStringEndsWith( 'cheer.jpg', $this->api()->quaggans()->get('cheer')->url );
+    }
+}

--- a/tests/V2/SkinEndpointTest.php
+++ b/tests/V2/SkinEndpointTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class SkinEndpointTest extends TestCase {
+    public function test() {
+        $this->mockResponse('[1,2,3,4,5,6,7,8,9,10]');
+
+        $this->assertEquals( [1,2,3,4,5,6,7,8,9,10], $this->api()->skins()->ids() );
+    }
+}

--- a/tests/V2/WorldEndpointTest.php
+++ b/tests/V2/WorldEndpointTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class WorldEndpointTest extends TestCase {
+    public function test() {
+        $this->mockResponse('[{"id":1001,"name":"Anvil Rock"}]');
+
+        $this->assertEquals( 'Anvil Rock', $this->api()->worlds()->many([1001])[0]->name );
+    }
+}


### PR DESCRIPTION
Adds tests for v2/account, v2/characters, v2/colors, v2/files, v2/items, v2/maps, v2/quaggans, v2/skins and v2/worlds.

These tests just exist to test if we can create instances of the endpoints, the underlying functions get tested by the pagination, bulk, ... tests. (see #1)