### PR TITLE
Brute force upgrade to guzzle 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 matrix:
   allow_failures:
-    - php: hhvm
     - php: 7.0
   fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "source": "https://github.com/GW2Treasures/gw2api"
     },
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "~5.2"
+        "php": ">=5.5.",
+        "guzzlehttp/guzzle": "~6.0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,25 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1adcbfd5a516107e8ac944f5ffb03711",
+    "hash": "13b02549643c363069d3296cd42e169b",
+    "content-hash": "07359956e2a349ff9c7628967bbc5194",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "5.2.0",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "475b29ccd411f2fa8a408e64576418728c032cfa"
+                "reference": "a8dfeff00eb84616a17fea7a4d72af35e750410f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/475b29ccd411f2fa8a408e64576418728c032cfa",
-                "reference": "475b29ccd411f2fa8a408e64576418728c032cfa",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a8dfeff00eb84616a17fea7a4d72af35e750410f",
+                "reference": "a8dfeff00eb84616a17fea7a4d72af35e750410f",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/ringphp": "~1.0",
-                "php": ">=5.4.0"
+                "guzzlehttp/promises": "~1.0",
+                "guzzlehttp/psr7": "~1.1",
+                "php": ">=5.5.0"
             },
             "require-dev": {
                 "ext-curl": "*",
@@ -32,10 +34,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
                 }
@@ -51,7 +56,7 @@
                     "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "description": "Guzzle is a PHP HTTP client library",
             "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
@@ -62,33 +67,27 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-01-28 01:03:29"
+            "time": "2015-07-04 20:09:24"
         },
         {
-            "name": "guzzlehttp/ringphp",
-            "version": "1.0.7",
+            "name": "guzzlehttp/promises",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "52d868f13570a9a56e5fce6614e0ec75d0f13ac2"
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "97fe7210def29451ec74923b27e552238defd75a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/52d868f13570a9a56e5fce6614e0ec75d0f13ac2",
-                "reference": "52d868f13570a9a56e5fce6614e0ec75d0f13ac2",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/97fe7210def29451ec74923b27e552238defd75a",
+                "reference": "97fe7210def29451ec74923b27e552238defd75a",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/streams": "~3.0",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
+                "php": ">=5.5.0"
             },
             "require-dev": {
-                "ext-curl": "*",
                 "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
             },
             "type": "library",
             "extra": {
@@ -98,99 +97,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "time": "2015-03-30 01:43:20"
-        },
-        {
-            "name": "guzzlehttp/streams",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "time": "2014-10-12 19:18:40"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
-                "reference": "365fcee430dfa4ace1fbc75737ca60ceea7eeeef",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
+                    "GuzzleHttp\\Promise\\": "src/"
                 },
                 "files": [
                     "src/functions_include.php"
@@ -202,27 +109,138 @@
             ],
             "authors": [
                 {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@googlemail.com"
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
                 }
             ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "time": "2014-12-30 13:32:42"
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2015-08-15 19:37:21"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "reference": "4ef919b0cf3b1989523138b60163bbcb7ba1ff7e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "PSR-7 message implementation",
+            "keywords": [
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-08-15 19:32:36"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119"
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f976e5de371104877ebc89bd8fecb0019ed9c119",
-                "reference": "f976e5de371104877ebc89bd8fecb0019ed9c119",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
                 "shasum": ""
             },
             "require": {
@@ -233,7 +251,7 @@
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "2.0.*@ALPHA"
+                "squizlabs/php_codesniffer": "~2.0"
             },
             "type": "library",
             "extra": {
@@ -242,8 +260,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Instantiator\\": "src"
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -263,102 +281,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2014-10-13 12:58:55"
-        },
-        {
-            "name": "guzzle/guzzle",
-            "version": "v3.9.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/guzzle3.git",
-                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/0645b70d953bc1c067bbc8d5bc53194706b628d9",
-                "reference": "0645b70d953bc1c067bbc8d5bc53194706b628d9",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "php": ">=5.3.3",
-                "symfony/event-dispatcher": "~2.1"
-            },
-            "replace": {
-                "guzzle/batch": "self.version",
-                "guzzle/cache": "self.version",
-                "guzzle/common": "self.version",
-                "guzzle/http": "self.version",
-                "guzzle/inflection": "self.version",
-                "guzzle/iterator": "self.version",
-                "guzzle/log": "self.version",
-                "guzzle/parser": "self.version",
-                "guzzle/plugin": "self.version",
-                "guzzle/plugin-async": "self.version",
-                "guzzle/plugin-backoff": "self.version",
-                "guzzle/plugin-cache": "self.version",
-                "guzzle/plugin-cookie": "self.version",
-                "guzzle/plugin-curlauth": "self.version",
-                "guzzle/plugin-error-response": "self.version",
-                "guzzle/plugin-history": "self.version",
-                "guzzle/plugin-log": "self.version",
-                "guzzle/plugin-md5": "self.version",
-                "guzzle/plugin-mock": "self.version",
-                "guzzle/plugin-oauth": "self.version",
-                "guzzle/service": "self.version",
-                "guzzle/stream": "self.version"
-            },
-            "require-dev": {
-                "doctrine/cache": "~1.3",
-                "monolog/monolog": "~1.0",
-                "phpunit/phpunit": "3.7.*",
-                "psr/log": "~1.0",
-                "symfony/class-loader": "~2.1",
-                "zendframework/zend-cache": "2.*,<2.3",
-                "zendframework/zend-log": "2.*,<2.3"
-            },
-            "suggest": {
-                "guzzlehttp/guzzle": "Guzzle 5 has moved to a new package name. The package you have installed, Guzzle 3, is deprecated."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Guzzle": "src/",
-                    "Guzzle\\Tests": "tests/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Guzzle Community",
-                    "homepage": "https://github.com/guzzle/guzzle/contributors"
-                }
-            ],
-            "description": "PHP HTTP client. This library is deprecated in favor of https://packagist.org/packages/guzzlehttp/guzzle",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2015-03-18 18:23:50"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "mtdowling/burgomaster",
@@ -452,16 +375,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.4.1",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "3132b1f44c7bf2ec4c7eb2d3cb78fdeca760d373"
+                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3132b1f44c7bf2ec4c7eb2d3cb78fdeca760d373",
-                "reference": "3132b1f44c7bf2ec4c7eb2d3cb78fdeca760d373",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
                 "shasum": ""
             },
             "require": {
@@ -508,20 +431,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-04-27 22:15:08"
+            "time": "2015-08-13 10:07:40"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.0.16",
+            "version": "2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c"
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/934fd03eb6840508231a7f73eb8940cf32c3b66c",
-                "reference": "934fd03eb6840508231a7f73eb8940cf32c3b66c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef1ca6835468857944d5c3b48fa503d5554cff2f",
+                "reference": "ef1ca6835468857944d5c3b48fa503d5554cff2f",
                 "shasum": ""
             },
             "require": {
@@ -529,7 +452,7 @@
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "~1.0",
+                "sebastian/environment": "^1.3.2",
                 "sebastian/version": "~1.0"
             },
             "require-dev": {
@@ -544,7 +467,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -570,20 +493,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-04-11 04:35:00"
+            "time": "2015-09-14 06:51:16"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a923bb15680d0089e2316f7a4af8f437046e96bb",
-                "reference": "a923bb15680d0089e2316f7a4af8f437046e96bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
@@ -617,20 +540,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-04-02 05:19:05"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
-                "reference": "206dfefc0ffe9cebf65c413e3d0e809c82fbf00a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -639,20 +562,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -661,20 +581,20 @@
             "keywords": [
                 "template"
             ],
-            "time": "2014-01-30 17:20:04"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.5",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
                 "shasum": ""
             },
             "require": {
@@ -683,13 +603,10 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -705,20 +622,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2015-06-21 08:01:12"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.1",
+            "version": "1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "eab81d02569310739373308137284e0158424330"
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/eab81d02569310739373308137284e0158424330",
-                "reference": "eab81d02569310739373308137284e0158424330",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
                 "shasum": ""
             },
             "require": {
@@ -754,20 +671,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-04-08 04:46:07"
+            "time": "2015-09-15 10:49:45"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.6.6",
+            "version": "4.8.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3afe303d873a4d64c62ef84de491b97b006fbdac"
+                "reference": "73fad41adb5b7bc3a494bb930d90648df1d5e74b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3afe303d873a4d64c62ef84de491b97b006fbdac",
-                "reference": "3afe303d873a4d64c62ef84de491b97b006fbdac",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/73fad41adb5b7bc3a494bb930d90648df1d5e74b",
+                "reference": "73fad41adb5b7bc3a494bb930d90648df1d5e74b",
                 "shasum": ""
             },
             "require": {
@@ -777,15 +694,15 @@
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpspec/prophecy": "~1.3,>=1.3.1",
-                "phpunit/php-code-coverage": "~2.0,>=2.0.11",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "~2.1",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "~1.0",
+                "phpunit/php-timer": ">=1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
                 "sebastian/comparator": "~1.1",
                 "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.2",
+                "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
                 "sebastian/global-state": "~1.0",
                 "sebastian/version": "~1.0",
@@ -800,7 +717,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.6.x-dev"
+                    "dev-master": "4.8.x-dev"
                 }
             },
             "autoload": {
@@ -826,26 +743,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-04-29 15:18:52"
+            "time": "2015-09-20 12:56:44"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.1",
+            "version": "2.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c"
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/74ffb87f527f24616f72460e54b595f508dccb5c",
-                "reference": "74ffb87f527f24616f72460e54b595f508dccb5c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "~1.0,>=1.0.2",
+                "doctrine/instantiator": "^1.0.2",
                 "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2"
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -881,58 +799,20 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-04-02 05:36:41"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "shasum": ""
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2015-08-19 09:14:08"
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e"
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dd8869519a225f7f2b9eb663e225298fade819e",
-                "reference": "1dd8869519a225f7f2b9eb663e225298fade819e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
                 "shasum": ""
             },
             "require": {
@@ -946,7 +826,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -983,7 +863,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-01-29 16:28:08"
+            "time": "2015-07-26 15:48:44"
         },
         {
             "name": "sebastian/diff",
@@ -1039,16 +919,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.2.2",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e"
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5a8c7d31914337b69923db26c4221b81ff5a196e",
-                "reference": "5a8c7d31914337b69923db26c4221b81ff5a196e",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
                 "shasum": ""
             },
             "require": {
@@ -1085,20 +965,20 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-01-01 10:01:08"
+            "time": "2015-08-03 06:14:51"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "84839970d05254c73cde183a721c7af13aede943"
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/84839970d05254c73cde183a721c7af13aede943",
-                "reference": "84839970d05254c73cde183a721c7af13aede943",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
+                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
                 "shasum": ""
             },
             "require": {
@@ -1151,7 +1031,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-01-27 07:23:06"
+            "time": "2015-06-21 07:55:53"
         },
         {
             "name": "sebastian/global-state",
@@ -1206,16 +1086,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252"
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/3989662bbb30a29d20d9faa04a846af79b276252",
-                "reference": "3989662bbb30a29d20d9faa04a846af79b276252",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
                 "shasum": ""
             },
             "require": {
@@ -1255,20 +1135,20 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-01-24 09:48:32"
+            "time": "2015-06-21 08:04:50"
         },
         {
             "name": "sebastian/version",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4"
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
-                "reference": "ab931d46cd0d3204a91e1b9a40c4bc13032b58e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
                 "shasum": ""
             },
             "type": "library",
@@ -1290,293 +1170,24 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-02-24 06:35:25"
-        },
-        {
-            "name": "symfony/config",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Config",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Config.git",
-                "reference": "b6fddb4aa2daaa2b06f0040071ac131b4a1ecf25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/b6fddb4aa2daaa2b06f0040071ac131b4a1ecf25",
-                "reference": "b6fddb4aa2daaa2b06f0040071ac131b4a1ecf25",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "symfony/filesystem": "~2.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Config\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Config Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
-        },
-        {
-            "name": "symfony/console",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Console",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Console.git",
-                "reference": "ebc5679854aa24ed7d65062e9e3ab0b18a917272"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/ebc5679854aa24ed7d65062e9e3ab0b18a917272",
-                "reference": "ebc5679854aa24ed7d65062e9e3ab0b18a917272",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.1"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Console\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Console Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
-        },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/EventDispatcher",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/672593bc4b0043a0acf91903bb75a1c82d8f2e02",
-                "reference": "672593bc4b0043a0acf91903bb75a1c82d8f2e02",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/stopwatch": "~2.3"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Filesystem",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "f73904bd2dae525c42ea1f0340c7c98480ecacde"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/f73904bd2dae525c42ea1f0340c7c98480ecacde",
-                "reference": "f73904bd2dae525c42ea1f0340c7c98480ecacde",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Filesystem Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-05-08 00:09:07"
-        },
-        {
-            "name": "symfony/stopwatch",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Stopwatch",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/Stopwatch.git",
-                "reference": "b470f87c69837cb71115f1fa720388bb19b63635"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/b470f87c69837cb71115f1fa720388bb19b63635",
-                "reference": "b470f87c69837cb71115f1fa720388bb19b63635",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\Stopwatch\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Stopwatch Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-06-21 13:59:46"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.6.7",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
-                "reference": "f157ab074e453ecd4c0fa775f721f6e67a99d9e2",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
+                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "symfony/phpunit-bridge": "~2.7"
@@ -1584,11 +1195,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
                 }
             },
@@ -1608,7 +1219,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-05-02 15:18:45"
+            "time": "2015-09-14 14:14:09"
         }
     ],
     "aliases": [],
@@ -1617,7 +1228,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0"
+        "php": ">=5.5."
     },
     "platform-dev": []
 }

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -3,7 +3,7 @@
 namespace GW2Treasures\GW2Api\Exception;
 
 use Exception;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class ApiException extends Exception {
     /** @var ResponseInterface $response */
@@ -25,6 +25,6 @@ class ApiException extends Exception {
     public function __toString() {
         return $this->message . ' (' .
                'status: ' . $this->response->getStatusCode() . '; ' .
-               'url: ' . $this->response->getEffectiveUrl() . ')';
+               'url: ' . $this->response->getHeaderLine('X-GUZZLE-EFFECTIVE-URL') . ')';
     }
 }

--- a/src/GW2Api.php
+++ b/src/GW2Api.php
@@ -3,6 +3,8 @@
 namespace GW2Treasures\GW2Api;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GW2Treasures\GW2Api\Middleware\EffectiveUrlMiddleware;
 use GW2Treasures\GW2Api\V2\Endpoint\Account\AccountEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Build\BuildEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Character\CharacterEndpoint;
@@ -52,11 +54,14 @@ class GW2Api {
     }
 
     protected function getOptions( array $options = [] ) {
+        $handler_stack = (isset($options['handler'])) ? $options['handler'] : HandlerStack::create();
+        $handler_stack->push(EffectiveUrlMiddleware::middleware());
         return [
            'base_url' => $this->apiUrl,
            'defaults' => [
                'verify' => $this->getCacertFilePath()
-           ]
+           ],
+           'handler' => $handler_stack
         ] + $options;
     }
 

--- a/src/Middleware/EffectiveUrlMiddleware.php
+++ b/src/Middleware/EffectiveUrlMiddleware.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace GW2Treasures\GW2Api\Middleware;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * This puts the effective url into a header.
+ *
+ * With guzzle 6 it is no longer possible to get the effective url directly
+ *   from the response.
+ * By using this middleware the effective url get's put on a header which
+ *   CAN be accessed on the response.
+ * Source: https://gist.github.com/Thinkscape/43499cfafda1af8f606d#file-effectiveurlmiddleware-php
+ */
+class EffectiveUrlMiddleware
+{
+  /**
+   * @var Callable
+   */
+  protected $nextHandler;
+  /**
+   * @var string
+   */
+  protected $headerName;
+  /**
+   * @param callable $nextHandler
+   * @param string   $headerName  The header name to use for storing effective url
+   */
+  public function __construct(
+    callable $nextHandler,
+    $headerName = 'X-GUZZLE-EFFECTIVE-URL'
+  ) {
+    $this->nextHandler = $nextHandler;
+    $this->headerName = $headerName;
+  }
+  /**
+   * Inject effective-url header into response.
+   *
+   * @param RequestInterface $request
+   * @param array            $options
+   *
+   * @return RequestInterface
+   */
+  public function __invoke(RequestInterface $request, array $options)
+  {
+    $fn = $this->nextHandler;
+    return $fn($request, $options)->then(function (ResponseInterface $response) use ($request, $options) {
+      return $response->withAddedHeader($this->headerName, $request->getUri()->__toString());
+    });
+  }
+  /**
+   * Prepare a middleware closure to be used with HandlerStack
+   *
+   * @param string $headerName The header name to use for storing effective url
+   *
+   * @return \Closure
+   */
+  public static function middleware($headerName = 'X-GUZZLE-EFFECTIVE-URL')
+  {
+    return function (callable $handler) use (&$headerName) {
+      return new static($handler, $headerName);
+    };
+  }
+}

--- a/src/V2/ApiHandler.php
+++ b/src/V2/ApiHandler.php
@@ -2,8 +2,8 @@
 
 namespace GW2Treasures\GW2Api\V2;
 
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 abstract class ApiHandler {
     /** @var IEndpoint $endpoint */
@@ -30,9 +30,9 @@ abstract class ApiHandler {
      */
     protected function getResponseAsJson( ResponseInterface $response ) {
         if( $response->hasHeader('Content-Type') ) {
-            $contentType = $response->getHeader('Content-Type');
+            $contentType = array_shift($response->getHeader('Content-Type'));
             if( stripos( $contentType, 'application/json' ) === 0 ) {
-                return $response->json([ 'object' => true ]);
+                return \json_decode($response->getBody(), FALSE);
             }
         }
 
@@ -40,11 +40,15 @@ abstract class ApiHandler {
     }
 
     /**
-     * Modify request before it is getting send.
+     * Return an updated request that should be send.
      *
      * @param RequestInterface $request
+     *
+     * @return RequestInterface
      */
-    public function onRequest( RequestInterface $request ) { }
+    public function onRequest( RequestInterface $request ) {
+      return $request;
+    }
 
     /**
      * Modify response before it gets processed.

--- a/src/V2/ApiHandler.php
+++ b/src/V2/ApiHandler.php
@@ -41,6 +41,27 @@ abstract class ApiHandler {
     }
 
     /**
+     * Returns the parsed query string for the passed request as key-value array.
+     *
+     * @param \Psr\Http\Message\RequestInterface $request
+     *
+     * @return array
+     */
+    protected function getQueryAsArray( RequestInterface $request ) {
+        $query = $request->getUri()->getQuery();
+        $pairs = explode('&', $query);
+        $query_array = [];
+        foreach ($pairs AS $pair) {
+            if (empty($pair)) {
+                continue;
+            }
+            list($key, $value) = explode('=', $pair);
+            $query_array[$key] = $value;
+        }
+        return $query_array;
+    }
+
+    /**
      * Return an updated request that should be send.
      *
      * @param RequestInterface $request

--- a/src/V2/ApiHandler.php
+++ b/src/V2/ApiHandler.php
@@ -30,7 +30,8 @@ abstract class ApiHandler {
      */
     protected function getResponseAsJson( ResponseInterface $response ) {
         if( $response->hasHeader('Content-Type') ) {
-            $contentType = array_shift($response->getHeader('Content-Type'));
+            $header_values = $response->getHeader('Content-Type');
+            $contentType = array_shift($header_values);
             if( stripos( $contentType, 'application/json' ) === 0 ) {
                 return \json_decode($response->getBody(), FALSE);
             }

--- a/src/V2/ApiResponse.php
+++ b/src/V2/ApiResponse.php
@@ -2,7 +2,7 @@
 
 namespace GW2Treasures\GW2Api\V2;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class ApiResponse {
     /** @var ResponseInterface $response*/
@@ -28,6 +28,7 @@ class ApiResponse {
      * @return mixed
      */
     public function json( array $config = [] ) {
-        return $this->response->json( ['object' => true] + $config );
+        $options = isset($config['big_int_strings']) ? JSON_BIGINT_AS_STRING : 0;
+        return \json_decode($this->response->getBody(), FALSE, 512, $options);
     }
 }

--- a/src/V2/Authentication/AuthenticationHandler.php
+++ b/src/V2/Authentication/AuthenticationHandler.php
@@ -2,8 +2,8 @@
 
 namespace GW2Treasures\GW2Api\V2\Authentication;
 
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use GW2Treasures\GW2Api\V2\ApiHandler;
 use GW2Treasures\GW2Api\V2\Authentication\Exception\AuthenticationException;
 use GW2Treasures\GW2Api\V2\Authentication\Exception\InvalidPermissionsException;
@@ -16,14 +16,15 @@ class AuthenticationHandler extends ApiHandler {
         parent::__construct( $endpoint );
     }
 
-
     /**
      * Add the API key as Authorization header.
      *
      * @param RequestInterface $request
+     *
+     * @return \Psr\Http\Message\MessageInterface|\Psr\Http\Message\RequestInterface
      */
     public function onRequest( RequestInterface $request ) {
-        $request->addHeader( 'Authorization', 'Bearer ' . $this->getEndpoint()->getApiKey() );
+        return $request->withHeader( 'Authorization', 'Bearer ' . $this->getEndpoint()->getApiKey() );
     }
 
     /**

--- a/src/V2/Authentication/Exception/InvalidPermissionsException.php
+++ b/src/V2/Authentication/Exception/InvalidPermissionsException.php
@@ -2,7 +2,7 @@
 
 namespace GW2Treasures\GW2Api\V2\Authentication\Exception;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class InvalidPermissionsException extends AuthenticationException {
     /** @var string $missingScope */

--- a/src/V2/Endpoint.php
+++ b/src/V2/Endpoint.php
@@ -165,7 +165,8 @@ abstract class Endpoint implements IEndpoint {
         $responseJson = null;
 
         if( $response->hasHeader('Content-Type') ) {
-            $contentType = array_shift($response->getHeader('Content-Type'));
+            $header_values = $response->getHeader('Content-Type');
+            $contentType = array_shift($header_values);
             if( stripos( $contentType, 'application/json' ) === 0 ) {
                 $responseJson = \json_decode($response->getBody());
             }

--- a/src/V2/Endpoint.php
+++ b/src/V2/Endpoint.php
@@ -4,9 +4,11 @@ namespace GW2Treasures\GW2Api\V2;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Pool;
 use GW2Treasures\GW2Api\Exception\ApiException;
 use GW2Treasures\GW2Api\GW2Api;
@@ -54,7 +56,7 @@ abstract class Endpoint implements IEndpoint {
         $request = $this->createRequest( $query, $url, $method, $options );
 
         foreach( $this->handlers as $handler ) {
-            $handler->onRequest( $request );
+            $request = $handler->onRequest( $request );
         }
 
         try {
@@ -97,7 +99,7 @@ abstract class Endpoint implements IEndpoint {
             $request = $this->createRequest( $query, $url, $method, $options );
 
             foreach( $this->handlers as $handler ) {
-                $handler->onRequest( $request );
+                $request = $handler->onRequest( $request );
             }
 
             $requests[] = $request;
@@ -146,7 +148,11 @@ abstract class Endpoint implements IEndpoint {
      */
     protected function createRequest( array $query = [], $url = null, $method = 'GET', $options = [] ) {
         $url = !is_null( $url ) ? $url : $this->url();
-        return $this->getClient()->createRequest( $method, $url, $options + [ 'query' => $query ]);
+        $uri = new Uri($url);
+        foreach ($query AS $key => $value) {
+            $uri = Uri::withQueryValue($uri, $key, $value);
+        }
+        return new Request($method, $uri, $options);
     }
 
     /**
@@ -159,9 +165,9 @@ abstract class Endpoint implements IEndpoint {
         $responseJson = null;
 
         if( $response->hasHeader('Content-Type') ) {
-            $contentType = $response->getHeader('Content-Type');
+            $contentType = array_shift($response->getHeader('Content-Type'));
             if( stripos( $contentType, 'application/json' ) === 0 ) {
-                $responseJson = $response->json([ 'object' => true ]);
+                $responseJson = \json_decode($response->getBody());
             }
         }
 

--- a/src/V2/Localization/Exception/InvalidLanguageException.php
+++ b/src/V2/Localization/Exception/InvalidLanguageException.php
@@ -2,7 +2,7 @@
 
 namespace GW2Treasures\GW2Api\V2\Localization\Exception;
 
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\ResponseInterface;
 use GW2Treasures\GW2Api\Exception\ApiException;
 
 class InvalidLanguageException extends ApiException {

--- a/src/V2/Localization/LocalizationHandler.php
+++ b/src/V2/Localization/LocalizationHandler.php
@@ -29,19 +29,10 @@ class LocalizationHandler extends ApiHandler {
     }
 
     public function onResponse( ResponseInterface $response, RequestInterface $request ) {
-        $query = $request->getUri()->getQuery();
-        $pairs = explode('&', $query);
-        $query_array = [];
-        foreach ($pairs AS $pair) {
-            if (empty($pair)) {
-                continue;
-            }
-            list($key, $value) = explode('=', $pair);
-            $query_array[$key] = $value;
-        }
+        $query = $this->getQueryAsArray($request);
         $header_values = $response->getHeader( 'Content-Language' );
 
-        $requestLanguage = (isset($query_array['lang'])) ? $query_array['lang'] : NULL;
+        $requestLanguage = (isset($query['lang'])) ? $query['lang'] : NULL;
         $responseLanguage = (!empty($header_values)) ? array_shift($header_values) : NULL;
 
         if( $requestLanguage !== $responseLanguage) {

--- a/src/V2/Localization/LocalizationHandler.php
+++ b/src/V2/Localization/LocalizationHandler.php
@@ -2,8 +2,9 @@
 
 namespace GW2Treasures\GW2Api\V2\Localization;
 
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use GW2Treasures\GW2Api\V2\ApiHandler;
 use GW2Treasures\GW2Api\V2\Localization\Exception\InvalidLanguageException;
 
@@ -15,21 +16,35 @@ class LocalizationHandler extends ApiHandler {
         parent::__construct( $endpoint );
     }
 
-
     /**
      * Adds the `lang` query parameter to the request for localized endpoints.
      *
      * @param RequestInterface $request
+     *
+     * @return \Psr\Http\Message\RequestInterface
      */
     public function onRequest( RequestInterface $request ) {
-        $request->getQuery()->add( 'lang', $this->getEndpoint()->getLang() );
+        $new_uri = Uri::withQueryValue( $request->getUri(), 'lang', $this->getEndpoint()->getLang() );
+        return $request->withUri($new_uri);
     }
 
     public function onResponse( ResponseInterface $response, RequestInterface $request ) {
-        $requestLanguage = $request->getQuery()->get('lang');
-        $responseLanguage = $response->getHeader( 'Content-Language' );
+        $query = $request->getUri()->getQuery();
+        $pairs = explode('&', $query);
+        $query_array = [];
+        foreach ($pairs AS $pair) {
+            if (empty($pair)) {
+                continue;
+            }
+            list($key, $value) = explode('=', $pair);
+            $query_array[$key] = $value;
+        }
+        $header_values = $response->getHeader( 'Content-Language' );
 
-        if( $requestLanguage !== $responseLanguage ) {
+        $requestLanguage = (isset($query_array['lang'])) ? $query_array['lang'] : NULL;
+        $responseLanguage = (!empty($header_values)) ? array_shift($header_values) : NULL;
+
+        if( $requestLanguage !== $responseLanguage) {
             $message = 'Invalid language (expected: ' . $requestLanguage . '; actual: ' . $responseLanguage . ')';
             throw new InvalidLanguageException( $message, $requestLanguage, $responseLanguage, $response );
         }

--- a/src/V2/Pagination/PaginatedEndpoint.php
+++ b/src/V2/Pagination/PaginatedEndpoint.php
@@ -29,7 +29,7 @@ trait PaginatedEndpoint {
         $size = $this->maxPageSize();
 
         $firstPageResponse = $this->request( $this->createPaginatedRequestQuery( 0, $size ) );
-        $total = $firstPageResponse->getResponse()->getHeader('X-Result-Total');
+        $total = array_shift($firstPageResponse->getResponse()->getHeader('X-Result-Total'));
 
         $result = $firstPageResponse->json();
 
@@ -94,7 +94,7 @@ trait PaginatedEndpoint {
         $size = $this->maxPageSize();
 
         $firstPageResponse = $this->request( $this->createPaginatedRequestQuery( 0, $size ) );
-        $total = $firstPageResponse->getResponse()->getHeader('X-Result-Total');
+        $total = array_shift($firstPageResponse->getResponse()->getHeader('X-Result-Total'));
 
         $callback( $firstPageResponse->json() );
         unset( $firstPageResponse );

--- a/src/V2/Pagination/PaginatedEndpoint.php
+++ b/src/V2/Pagination/PaginatedEndpoint.php
@@ -29,7 +29,8 @@ trait PaginatedEndpoint {
         $size = $this->maxPageSize();
 
         $firstPageResponse = $this->request( $this->createPaginatedRequestQuery( 0, $size ) );
-        $total = array_shift($firstPageResponse->getResponse()->getHeader('X-Result-Total'));
+        $header_values = $firstPageResponse->getResponse()->getHeader('X-Result-Total');
+        $total = array_shift($header_values);
 
         $result = $firstPageResponse->json();
 
@@ -94,7 +95,8 @@ trait PaginatedEndpoint {
         $size = $this->maxPageSize();
 
         $firstPageResponse = $this->request( $this->createPaginatedRequestQuery( 0, $size ) );
-        $total = array_shift($firstPageResponse->getResponse()->getHeader('X-Result-Total'));
+        $header_values = $firstPageResponse->getResponse()->getHeader('X-Result-Total');
+        $total = array_shift($header_values);
 
         $callback( $firstPageResponse->json() );
         unset( $firstPageResponse );

--- a/src/V2/Pagination/PaginationHandler.php
+++ b/src/V2/Pagination/PaginationHandler.php
@@ -2,8 +2,8 @@
 
 namespace GW2Treasures\GW2Api\V2\Pagination;
 
-use GuzzleHttp\Message\RequestInterface;
-use GuzzleHttp\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use GW2Treasures\GW2Api\V2\ApiHandler;
 use GW2Treasures\GW2Api\V2\Pagination\Exception\PageOutOfRangeException;
 

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -35,7 +35,8 @@ class ApiExceptionTest extends TestCase {
             $this->getEndpoint()->test();
         } catch( \GW2Treasures\GW2Api\Exception\ApiException $exception ) {
             $this->assertNotNull( $exception->getResponse() );
-            $this->assertEquals( 'bar', array_shift($exception->getResponse()->getHeader('foo')) );
+            $header_values = $exception->getResponse()->getHeader('foo');
+            $this->assertEquals( 'bar', array_shift($header_values) );
             $this->assertEquals( 400, $exception->getCode() );
             $this->assertEquals( 400, $exception->getResponse()->getStatusCode() );
 

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -1,9 +1,9 @@
 <?php
 
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Message\Request;
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7;
 use Stubs\EndpointStub;
 
 class ApiExceptionTest extends TestCase {
@@ -19,7 +19,7 @@ class ApiExceptionTest extends TestCase {
     public function testMessage() {
         $this->mockResponse( new Response(
             400, [ 'Content-Type' => 'application/json; charset=utf-8' ],
-            Stream::factory( '{"text":"this is the error message."}' )
+            Psr7\stream_for( '{"text":"this is the error message."}' )
         ));
 
         $this->getEndpoint()->test();
@@ -28,14 +28,14 @@ class ApiExceptionTest extends TestCase {
     public function testResponse() {
         $this->mockResponse( new Response(
             400, [ 'Content-Type' => 'application/json; charset=utf-8', 'foo' => 'bar' ],
-            Stream::factory( '{"text":"this is the error message."}' )
+            Psr7\stream_for( '{"text":"this is the error message."}' )
         ));
 
         try {
             $this->getEndpoint()->test();
         } catch( \GW2Treasures\GW2Api\Exception\ApiException $exception ) {
             $this->assertNotNull( $exception->getResponse() );
-            $this->assertEquals( 'bar', $exception->getResponse()->getHeader('foo') );
+            $this->assertEquals( 'bar', array_shift($exception->getResponse()->getHeader('foo')) );
             $this->assertEquals( 400, $exception->getCode() );
             $this->assertEquals( 400, $exception->getResponse()->getStatusCode() );
 
@@ -50,7 +50,7 @@ class ApiExceptionTest extends TestCase {
      */
     public function testUnknownException() {
         $this->mockResponse( new Response(
-            500, [], Stream::factory( 'Internal server error' )
+            500, [], Psr7\stream_for( 'Internal server error' )
         ));
 
         $this->getEndpoint()->test();
@@ -76,7 +76,7 @@ class ApiExceptionTest extends TestCase {
     public function testRequestManyExceptionWithoutResponse() {
         $this->mockResponse( new Response(
             200, [ 'X-Result-Total' => 10, 'Content-Type' => 'application/json; charset=utf-8' ],
-            Stream::factory( '[1,2,3]' )
+            Psr7\stream_for( '[1,2,3]' )
         ));
         $this->mockResponse(
             new ConnectException('RequestManyExceptionWithoutResponse', new Request('GET', 'test/exception'))

--- a/tests/ApiHandlerTest.php
+++ b/tests/ApiHandlerTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use GW2Treasures\GW2Api\V2\ApiHandler;
 use GW2Treasures\GW2Api\V2\IEndpoint;
@@ -40,6 +43,25 @@ class ApiHandlerTest extends TestCase {
         $this->assertNull( $handler->responseAsJson( $invalidNoContentType ));
     }
 
+    public function testQueryParser() {
+        $endpoint = $this->getEndpoint();
+        $handler = $this->getHandler( $endpoint );
+        $request = new Request('GET', new Uri($endpoint->url()));
+
+        $uri = $request->getUri()->withQuery('abc=123&def=456&ghi=789');
+        $query_array = $handler->queryAsArray($request->withUri($uri));
+        $this->assertEquals(3, count($query_array));
+        $this->assertArrayHasKey('abc', $query_array);
+        $this->assertArrayHasKey('def', $query_array);
+        $this->assertArrayHasKey('ghi', $query_array);
+
+        $uri = $request->getUri()->withQuery('abc=123&&ghi=789');
+        $query_array = $handler->queryAsArray($request->withUri($uri));
+        $this->assertEquals(2, count($query_array));
+        $this->assertArrayHasKey('abc', $query_array);
+        $this->assertArrayHasKey('ghi', $query_array);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -66,5 +88,9 @@ class ApiHandlerTest extends TestCase {
 class TestHandler extends ApiHandler {
     public function responseAsJson( ResponseInterface $response ) {
         return $this->getResponseAsJson( $response );
+    }
+
+    public function queryAsArray( RequestInterface $request ) {
+        return $this->getQueryAsArray($request);
     }
 }

--- a/tests/ApiHandlerTest.php
+++ b/tests/ApiHandlerTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Message\ResponseInterface;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message\ResponseInterface;
 use GW2Treasures\GW2Api\V2\ApiHandler;
 use GW2Treasures\GW2Api\V2\IEndpoint;
 use Stubs\EndpointStub;
@@ -23,7 +23,7 @@ class ApiHandlerTest extends TestCase {
             ? [ 'Content-Type' => $contentType ]
             : [];
 
-        return new Response( 200, $header, Stream::factory( $content ));
+        return new Response( 200, $header, Psr7\stream_for( $content ));
     }
 
     public function testAsJson() {

--- a/tests/AuthenticatedEndpointTest.php
+++ b/tests/AuthenticatedEndpointTest.php
@@ -22,7 +22,8 @@ class AuthenticatedEndpointTest extends TestCase {
         $request = $this->getLastRequest();
         $this->assertTrue( $request->hasHeader('Authorization'),
             'AuthenticatedEndpoint sets Authorization header' );
-        $this->assertEquals( 'Bearer test', array_shift($request->getHeader('Authorization')),
+        $header_values = $request->getHeader('Authorization');
+        $this->assertEquals( 'Bearer test', array_shift($header_values),
             'AuthenticatedEndpoint sets correct Authorization header' );
     }
 

--- a/tests/AuthenticatedEndpointTest.php
+++ b/tests/AuthenticatedEndpointTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use GuzzleHttp\Message\Response;
-use GuzzleHttp\Stream\Stream;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7;
 use GW2Treasures\GW2Api\V2\Authentication\Exception\InvalidPermissionsException;
 use Stubs\AuthenticatedEndpointStub;
 
@@ -22,7 +22,7 @@ class AuthenticatedEndpointTest extends TestCase {
         $request = $this->getLastRequest();
         $this->assertTrue( $request->hasHeader('Authorization'),
             'AuthenticatedEndpoint sets Authorization header' );
-        $this->assertEquals( 'Bearer test', $request->getHeader('Authorization'),
+        $this->assertEquals( 'Bearer test', array_shift($request->getHeader('Authorization')),
             'AuthenticatedEndpoint sets correct Authorization header' );
     }
 
@@ -33,7 +33,7 @@ class AuthenticatedEndpointTest extends TestCase {
     public function testInvalidKey() {
         $this->mockResponse( new Response(
             400, [ 'Content-Type' => 'application/json; charset=utf-8' ],
-            Stream::factory( '{"text":"invalid key"}' )
+            Psr7\stream_for( '{"text":"invalid key"}' )
         ));
 
         $this->getAuthenticatedEndpoint('invalid')->test();
@@ -42,7 +42,7 @@ class AuthenticatedEndpointTest extends TestCase {
     public function testInvalidPermissions() {
         $this->mockResponse( new Response(
             400, [ 'Content-Type' => 'application/json; charset=utf-8' ],
-            Stream::factory( '{"text":"requires scope characters"}' )
+            Psr7\stream_for( '{"text":"requires scope characters"}' )
         ));
 
         try {
@@ -66,7 +66,7 @@ class AuthenticatedEndpointTest extends TestCase {
     public function testUnknownError() {
         $this->mockResponse( new Response(
             400, [ 'Content-Type' => 'application/json; charset=utf-8' ],
-            Stream::factory( '{"text":"unknown error"}' )
+            Psr7\stream_for( '{"text":"unknown error"}' )
         ));
 
         $this->getAuthenticatedEndpoint('invalid')->test();

--- a/tests/LocalizedEndpointTest.php
+++ b/tests/LocalizedEndpointTest.php
@@ -18,9 +18,10 @@ class LocalizedEndpointTest extends TestCase {
         $endpoint->lang('en')->test();
 
         $request = $this->getLastRequest();
-        $this->assertTrue( $request->getQuery()->hasKey('lang'),
+        $query_array = $this->getQueryArray($request);
+        $this->assertArrayHasKey( 'lang', $query_array,
             'LocalizedEndpoint sets ?lang query parameter' );
-        $this->assertEquals( 'en', $request->getQuery()->get('lang'),
+        $this->assertEquals( 'en', $query_array['lang'],
             'LocalizedEndpoint sets correct query parameter value' );
     }
 
@@ -36,9 +37,10 @@ class LocalizedEndpointTest extends TestCase {
         $endpoint_de->test();
 
         $request = $this->getLastRequest();
-        $this->assertTrue( $request->getQuery()->hasKey('lang'),
+        $query_array = $this->getQueryArray($request);
+        $this->assertArrayHasKey( 'lang', $query_array,
             'LocalizedEndpoint sets ?lang query parameter on repeated request' );
-        $this->assertEquals( 'de', $request->getQuery()->get('lang'),
+        $this->assertEquals( 'de', $query_array['lang'],
             'LocalizedEndpoint sets correct query parameter value pm repeated request' );
     }
 
@@ -48,9 +50,10 @@ class LocalizedEndpointTest extends TestCase {
         $this->getLocalizedEndpoint()->lang('es')->lang('fr')->test();
 
         $request = $this->getLastRequest();
-        $this->assertTrue( $request->getQuery()->hasKey('lang'),
+        $query_array = $this->getQueryArray($request);
+        $this->assertArrayHasKey( 'lang', $query_array,
             'LocalizedEndpoint sets ?lang query parameter on nested request' );
-        $this->assertEquals( 'fr', $request->getQuery()->get('lang'),
+        $this->assertEquals( 'fr', $query_array['lang'],
             'LocalizedEndpoint sets correct query parameter value on nested request' );
     }
 


### PR DESCRIPTION
Issue #22 seemed to indicate that there is a general interest in using guzzle 6 for this project.

With this i chose the brute force route, trying get it to work with the minimal amount of changes necessary.
This may not be the most elegant solution but tests pass for me localy ;-)

Interaction with the new middleware layer is actually only necessary in tests (for the mock) and to add a custom handler to get back the getEffectiveUrl() functionality for  \GW2Treasures\GW2Api\Exception\ApiException::__toString() (though the solution is copied from another project: https://gist.github.com/Thinkscape/43499cfafda1af8f606d#file-effectiveurlmiddleware-php).

I would be happy if this help's push the project towards adopting guzzle 6 as it seems to be the only activly maintained php library and I wanted to use it within Drupal 8 (which by now requires guzzle 6).

BTW: This would push the required min php version to 5.5

Edit: Removed the Build against hhvm because: https://github.com/guzzle/guzzle/issues/1209