### PR TITLE
Stats endpoint wasn’t getting api key.

### DIFF
--- a/src/V2/Endpoint/Pvp/StatsEndpoint.php
+++ b/src/V2/Endpoint/Pvp/StatsEndpoint.php
@@ -2,6 +2,7 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
 
+use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
@@ -9,6 +10,15 @@ use GW2Treasures\GW2Api\V2\Endpoint;
 class StatsEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
 
+    /**
+     * @param GW2Api $api
+     * @param string $apiKey
+     */
+    public function __construct(GW2Api $api, $apiKey) {
+        $this->apiKey = $apiKey;
+
+        parent::__construct($api);
+    }
     /**
      * The url of this endpoint.
      *


### PR DESCRIPTION
Fixed issue with pvp/stats endpoint not being authenicated