### PR TITLE
Achievement endpoint doesn't support "all" keyword

### DIFF
--- a/src/V2/Endpoint/Achievement/AchievementEndpoint.php
+++ b/src/V2/Endpoint/Achievement/AchievementEndpoint.php
@@ -10,6 +10,9 @@ use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
 class AchievementEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint {
     use BulkEndpoint, LocalizedEndpoint;
+    
+    /** @var bool $supportsIdsAll */
+    protected $supportsIdsAll = false;
 
     /**
      * The url of this endpoint.


### PR DESCRIPTION
https://api.guildwars2.com/v2/achievements?ids=all

Saw that while looking through :)