### PR TITLE
Run tests for the .phar build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,21 @@ matrix:
       env: setup=lowest
     - php: 5.5
       env: setup=stable
+    - php: 5.6
+      env: setup=phar
 
 install:
   - if [[ $setup = 'basic' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
   - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-stable; fi
   - if [[ $setup = 'lowest' ]]; then travis_retry composer update --prefer-source --no-interaction --prefer-lowest --prefer-stable; fi
+  - if [[ $setup = 'phar' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
+
+before_script:
+  - if [[ $setup = 'phar' ]]; then php build/build.php; fi
 
 script:
-  - phpunit --configuration phpunit.xml --coverage-clover clover.xml
+  - if [[ $setup != 'phar' ]]; then vendor/bin/phpunit --configuration phpunit.xml --coverage-clover clover.xml; fi
+  - if [[ $setup = 'phar' ]]; then vendor/bin/phpunit --configuration phpunit.xml --bootstrap build/autoload.php; fi
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/build/autoload.php
+++ b/build/autoload.php
@@ -1,0 +1,9 @@
+<?php
+
+// load psr4
+require __DIR__.'/artifacts/gw2api.phar';
+
+// prevent composer from autoloading GW2Treasures\GW2Api\* from src
+/** @var \Composer\Autoload\ClassLoader $loader */
+$loader = require __DIR__.'/../vendor/autoload.php';
+$loader->setPsr4('GW2Treasures\\GW2Api\\', []);


### PR DESCRIPTION
This adds a new `setup=phar` env variable to the build matrix, which builds the .phar-archive (`php build/build.php`) and then runs the phpunit test suite against it by bootstraping `build/autoload.php`