### PR TITLE
Add global authentication

### DIFF
--- a/src/GW2Api.php
+++ b/src/GW2Api.php
@@ -37,10 +37,11 @@ use GW2Treasures\GW2Api\V2\Endpoint\Traits\TraitEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\World\WorldEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\WvW\WvWEndpoint;
 use GW2Treasures\GW2Api\V2\IEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\LocalizationHandler;
 use GW2Treasures\GW2Api\V2\Pagination\PaginationHandler;
 
-class GW2Api {
+class GW2Api implements IParent {
     /** @var string $apiUrl */
     protected $apiUrl = 'https://api.guildwars2.com/';
 
@@ -52,6 +53,9 @@ class GW2Api {
 
     /** @var array $handlers */
     protected $handlers = [];
+
+    /** @var string|null $apiKey */
+    protected $apiKey = null;
 
     function __construct( array $options = [] ) {
         $this->options = $this->getOptions( $options );
@@ -141,8 +145,8 @@ class GW2Api {
         return $this->client;
     }
 
-    public function account( $apiKey ) {
-        return new AccountEndpoint( $this, $apiKey );
+    public function account() {
+        return new AccountEndpoint( $this );
     }
 
     public function achievements() {
@@ -153,8 +157,8 @@ class GW2Api {
         return new BuildEndpoint( $this );
     }
 
-    public function characters( $apiKey ) {
-        return new CharacterEndpoint( $this, $apiKey );
+    public function characters() {
+        return new CharacterEndpoint( $this );
     }
 
     public function colors() {
@@ -237,8 +241,8 @@ class GW2Api {
         return new SpecializationEndpoint( $this );
     }
 
-    public function tokeninfo( $apiKey ) {
-        return new TokeninfoEndpoint( $this, $apiKey );
+    public function tokeninfo() {
+        return new TokeninfoEndpoint( $this );
     }
 
     public function traits() {
@@ -259,5 +263,30 @@ class GW2Api {
                 $endpoint->attach( new $handler( $endpoint ) );
             }
         }
+    }
+
+    public function getApi() {
+        return $this;
+    }
+
+    public function getParent() {
+        return null;
+    }
+
+
+    /**
+     * Set the API key that should be used to request this endpoint.
+     *
+     * @param string $apiKey
+     * @return static
+     */
+    public function auth($apiKey) {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    public function getApiKey() {
+        return $this->apiKey;
     }
 }

--- a/src/V2/Authentication/AuthenticatedEndpoint.php
+++ b/src/V2/Authentication/AuthenticatedEndpoint.php
@@ -2,7 +2,20 @@
 
 namespace GW2Treasures\GW2Api\V2\Authentication;
 
+use GW2Treasures\GW2Api\GW2Api;
+use GW2Treasures\GW2Api\V2\IParent;
+
 trait AuthenticatedEndpoint {
+    /**
+     * @return GW2Api
+     */
+    protected abstract function getApi();
+
+    /**
+     * @return IParent
+     */
+    protected abstract function getParent();
+
     /** @var string $apiKey */
     protected $apiKey;
 
@@ -12,6 +25,28 @@ trait AuthenticatedEndpoint {
      * @return string
      */
     public function getApiKey() {
-        return $this->apiKey;
+        if(isset($this->apiKey)) {
+            return $this->apiKey;
+        }
+
+        $parent = $this->getParent();
+
+        while (!($parent instanceof IAuthenticatedEndpoint || $parent instanceof GW2Api)) {
+            $parent = $parent->getParent();
+        }
+
+        return $parent->getApiKey();
+    }
+
+    /**
+     * Set the API key that should be used to request this endpoint.
+     *
+     * @param string $apiKey
+     * @return static
+     */
+    public function auth($apiKey) {
+        $this->apiKey = $apiKey;
+
+        return $this;
     }
 }

--- a/src/V2/Authentication/AuthenticationHandler.php
+++ b/src/V2/Authentication/AuthenticationHandler.php
@@ -25,7 +25,13 @@ class AuthenticationHandler extends ApiHandler {
      * @return MessageInterface|RequestInterface
      */
     public function onRequest( RequestInterface $request ) {
-        return $request->withHeader( 'Authorization', 'Bearer ' . $this->getEndpoint()->getApiKey() );
+        $apiKey = $this->getEndpoint()->getApiKey();
+
+        if($apiKey) {
+            return $request->withHeader( 'Authorization', 'Bearer '.$apiKey );
+        }
+
+        return $request;
     }
 
     /**

--- a/src/V2/Authentication/IAuthenticatedEndpoint.php
+++ b/src/V2/Authentication/IAuthenticatedEndpoint.php
@@ -11,4 +11,13 @@ interface IAuthenticatedEndpoint extends IEndpoint {
      * @return string
      */
     public function getApiKey();
+
+
+    /**
+     * Set the API key that should be used to request this endpoint.
+     *
+     * @param string $apiKey
+     * @return static
+     */
+    public function auth($apiKey);
 }

--- a/src/V2/Endpoint.php
+++ b/src/V2/Endpoint.php
@@ -13,20 +13,20 @@ use GW2Treasures\GW2Api\GW2Api;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-abstract class Endpoint implements IEndpoint {
-    /** @var GW2Api $api */
-    protected $api;
+abstract class Endpoint implements IEndpoint, IParent {
+    /** @var GW2Api $parent */
+    protected $parent;
 
     /** @var ApiHandler[] */
     protected $handlers = [];
 
     /**
-     * @param GW2Api $api
+     * @param IParent $parent
      */
-    public function __construct( GW2Api $api ) {
-        $this->api = $api;
+    public function __construct( IParent $parent ) {
+        $this->parent = $parent;
 
-        $this->api->attachRegisteredHandlers( $this );
+        $this->getApi()->attachRegisteredHandlers( $this );
     }
 
     /**
@@ -37,10 +37,17 @@ abstract class Endpoint implements IEndpoint {
     }
 
     /**
+     * @return IParent
+     */
+    public function getParent() {
+        return $this->parent;
+    }
+
+    /**
      * @return GW2Api
      */
-    protected function getApi() {
-        return $this->api;
+    public function getApi() {
+        return $this->getParent()->getApi();
     }
 
     /**

--- a/src/V2/Endpoint/Account/AccountEndpoint.php
+++ b/src/V2/Endpoint/Account/AccountEndpoint.php
@@ -2,7 +2,6 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
@@ -10,12 +9,6 @@ use GW2Treasures\GW2Api\V2\Endpoint;
 class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
 
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
-    
     /**
      * {@inheritdoc}
      */
@@ -38,7 +31,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return AchievementEndpoint
      */
     public function achievements() {
-        return new AchievementEndpoint( $this->api, $this->apiKey );
+        return new AchievementEndpoint( $this->parent );
     }
 
     /**
@@ -47,7 +40,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return BankEndpoint
      */
     public function bank() {
-        return new BankEndpoint( $this->api, $this->apiKey );
+        return new BankEndpoint( $this->parent );
     }
 
     /**
@@ -56,7 +49,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return DyeEndpoint
      */
     public function dyes() {
-        return new DyeEndpoint( $this->api, $this->apiKey );
+        return new DyeEndpoint( $this->parent );
     }
 
     /**
@@ -65,7 +58,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return InventoryEndpoint
      */
     public function inventory() {
-        return new InventoryEndpoint( $this->api, $this->apiKey );
+        return new InventoryEndpoint( $this->parent );
     }
 
     /**
@@ -74,7 +67,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return MaterialEndpoint
      */
     public function materials() {
-        return new MaterialEndpoint( $this->api, $this->apiKey );
+        return new MaterialEndpoint( $this->parent );
     }
 
     /**
@@ -83,7 +76,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return MiniEndpoint
      */
     public function minis() {
-        return new MiniEndpoint( $this->api, $this->apiKey );
+        return new MiniEndpoint( $this->parent );
     }
 
     /**
@@ -92,7 +85,7 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return SkinEndpoint
      */
     public function skins() {
-        return new SkinEndpoint( $this->api, $this->apiKey );
+        return new SkinEndpoint( $this->parent );
     }
 
     /**
@@ -101,6 +94,6 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return WalletEndpoint
      */
     public function wallet()  {
-        return new WalletEndpoint( $this->api, $this->apiKey );
+        return new WalletEndpoint( $this->parent );
     }
 }

--- a/src/V2/Endpoint/Account/AchievementEndpoint.php
+++ b/src/V2/Endpoint/Account/AchievementEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class AchievementEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/BankEndpoint.php
+++ b/src/V2/Endpoint/Account/BankEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class BankEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/DyeEndpoint.php
+++ b/src/V2/Endpoint/Account/DyeEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class DyeEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/InventoryEndpoint.php
+++ b/src/V2/Endpoint/Account/InventoryEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class InventoryEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/MaterialEndpoint.php
+++ b/src/V2/Endpoint/Account/MaterialEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class MaterialEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/MiniEndpoint.php
+++ b/src/V2/Endpoint/Account/MiniEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class MiniEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/SkinEndpoint.php
+++ b/src/V2/Endpoint/Account/SkinEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class SkinEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Account/WalletEndpoint.php
+++ b/src/V2/Endpoint/Account/WalletEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class WalletEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/V2/Endpoint/Achievement/AchievementEndpoint.php
+++ b/src/V2/Endpoint/Achievement/AchievementEndpoint.php
@@ -29,7 +29,7 @@ class AchievementEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedE
      * @return CategoryEndpoint
      */
     public function categories() {
-        return new CategoryEndpoint($this->api);
+        return new CategoryEndpoint($this->parent);
     }
 
     /**
@@ -38,7 +38,7 @@ class AchievementEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedE
      * @return DailyEndpoint
      */
     public function daily() {
-        return new DailyEndpoint($this->api);
+        return new DailyEndpoint($this->parent);
     }
 
     /**
@@ -47,6 +47,6 @@ class AchievementEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedE
      * @return GroupEndpoint
      */
     public function groups() {
-        return new GroupEndpoint($this->api);
+        return new GroupEndpoint($this->parent);
     }
 }

--- a/src/V2/Endpoint/Achievement/DailyEndpoint.php
+++ b/src/V2/Endpoint/Achievement/DailyEndpoint.php
@@ -29,6 +29,6 @@ class DailyEndpoint extends Endpoint {
      * @return DailyTomorrowEndpoint
      */
     public function tomorrow() {
-        return new DailyTomorrowEndpoint($this->api);
+        return new DailyTomorrowEndpoint($this->parent);
     }
 }

--- a/src/V2/Endpoint/Character/CharacterEndpoint.php
+++ b/src/V2/Endpoint/Character/CharacterEndpoint.php
@@ -2,7 +2,6 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Character;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
@@ -14,12 +13,6 @@ class CharacterEndpoint extends Endpoint implements IAuthenticatedEndpoint, IBul
 
     /** @var bool $supportsIdsAll */
     protected $supportsIdsAll = false;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}
@@ -35,7 +28,7 @@ class CharacterEndpoint extends Endpoint implements IAuthenticatedEndpoint, IBul
      * @return EquipmentEndpoint
      */
     public function equipmentOf( $character ) {
-        return new EquipmentEndpoint( $this->api, $this->apiKey, $character );
+        return new EquipmentEndpoint( $this->parent, $character );
     }
 
     /**
@@ -45,7 +38,7 @@ class CharacterEndpoint extends Endpoint implements IAuthenticatedEndpoint, IBul
      * @return InventoryEndpoint
      */
     public function inventoryOf( $character ) {
-        return new InventoryEndpoint( $this->api, $this->apiKey, $character );
+        return new InventoryEndpoint( $this->parent, $character );
     }
 
     /**
@@ -55,7 +48,7 @@ class CharacterEndpoint extends Endpoint implements IAuthenticatedEndpoint, IBul
      * @return RecipeEndpoint
      */
     public function recipesOf( $character ) {
-        return new RecipeEndpoint( $this->api, $this->apiKey, $character );
+        return new RecipeEndpoint( $this->parent, $character );
     }
 
     /**
@@ -65,6 +58,6 @@ class CharacterEndpoint extends Endpoint implements IAuthenticatedEndpoint, IBul
      * @return SpecializationEndpoint
      */
     public function specializationsOf( $character ) {
-        return new SpecializationEndpoint( $this->api, $this->apiKey, $character );
+        return new SpecializationEndpoint( $this->parent, $character );
     }
 }

--- a/src/V2/Endpoint/Character/EquipmentEndpoint.php
+++ b/src/V2/Endpoint/Character/EquipmentEndpoint.php
@@ -2,20 +2,19 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Character;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class EquipmentEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
 
     protected $character;
 
-    public function __construct( GW2Api $api, $apiKey, $character ) {
-        parent::__construct( $api );
+    public function __construct( IParent $parent, $character ) {
+        parent::__construct( $parent );
 
-        $this->apiKey = $apiKey;
         $this->character = $character;
     }
 

--- a/src/V2/Endpoint/Character/InventoryEndpoint.php
+++ b/src/V2/Endpoint/Character/InventoryEndpoint.php
@@ -2,20 +2,19 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Character;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class InventoryEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
 
     protected $character;
 
-    public function __construct( GW2Api $api, $apiKey, $character ) {
-        parent::__construct( $api );
+    public function __construct( IParent $parent, $character ) {
+        parent::__construct( $parent );
 
-        $this->apiKey = $apiKey;
         $this->character = $character;
     }
 

--- a/src/V2/Endpoint/Character/RecipeEndpoint.php
+++ b/src/V2/Endpoint/Character/RecipeEndpoint.php
@@ -2,20 +2,19 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Character;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class RecipeEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
 
     protected $character;
 
-    public function __construct( GW2Api $api, $apiKey, $character ) {
-        parent::__construct( $api );
+    public function __construct( IParent $parent, $character ) {
+        parent::__construct( $parent );
 
-        $this->apiKey = $apiKey;
         $this->character = $character;
     }
 

--- a/src/V2/Endpoint/Character/SpecializationEndpoint.php
+++ b/src/V2/Endpoint/Character/SpecializationEndpoint.php
@@ -2,20 +2,19 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Character;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class SpecializationEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
 
     protected $character;
 
-    public function __construct( GW2Api $api, $apiKey, $character ) {
-        parent::__construct( $api );
+    public function __construct( IParent $parent, $character ) {
+        parent::__construct( $parent );
 
-        $this->apiKey = $apiKey;
         $this->character = $character;
     }
 

--- a/src/V2/Endpoint/Commerce/CommerceEndpoint.php
+++ b/src/V2/Endpoint/Commerce/CommerceEndpoint.php
@@ -21,7 +21,7 @@ class CommerceEndpoint extends Endpoint {
      * @return ExchangeEndpoint
      */
     public function exchange() {
-        return new ExchangeEndpoint( $this->getApi() );
+        return new ExchangeEndpoint( $this->getParent() );
     }
 
     /**
@@ -30,7 +30,7 @@ class CommerceEndpoint extends Endpoint {
      * @return ListingEndpoint
      */
     public function listings() {
-        return new ListingEndpoint( $this->getApi() );
+        return new ListingEndpoint( $this->getParent() );
     }
 
     /**
@@ -39,16 +39,15 @@ class CommerceEndpoint extends Endpoint {
      * @return PriceEndpoint
      */
     public function prices() {
-        return new PriceEndpoint( $this->getApi() );
+        return new PriceEndpoint( $this->getParent() );
     }
 
     /**
      * Current and completed transactions.
      *
-     * @param string $apiKey
      * @return TransactionEndpoint
      */
-    public function transactions( $apiKey ) {
-        return new TransactionEndpoint( $this->getApi(), $apiKey );
+    public function transactions() {
+        return new TransactionEndpoint( $this->getParent() );
     }
 }

--- a/src/V2/Endpoint/Commerce/Transaction/ListEndpoint.php
+++ b/src/V2/Endpoint/Commerce/Transaction/ListEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Commerce\Transaction;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Pagination\IPaginatedEndpoint;
 use GW2Treasures\GW2Api\V2\Pagination\PaginatedEndpoint;
 use InvalidArgumentException;
@@ -22,24 +22,23 @@ class ListEndpoint extends Endpoint implements IAuthenticatedEndpoint, IPaginate
     /** @var string $list */
     protected $list;
 
-    public function __construct( GW2Api $api, $apiKey, $type, $list ) {
+    public function __construct( IParent $parent, $type, $list ) {
         if( !in_array( $type, self::$types )) {
             throw new InvalidArgumentException(
-                'Invalid $type ("' . $type . '""), has to be one of: ' . implode(', ', self::$types)
+                'Invalid $type ("' . $type . '"), has to be one of: ' . implode(', ', self::$types)
             );
         }
 
         if( !in_array( $list, self::$lists )) {
             throw new InvalidArgumentException(
-                'Invalid $list ("' . $list . '""), has to be one of: ' . implode(', ', self::$lists)
+                'Invalid $list ("' . $list . '"), has to be one of: ' . implode(', ', self::$lists)
             );
         }
 
         $this->type = $type;
         $this->list = $list;
-        $this->apiKey = $apiKey;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**

--- a/src/V2/Endpoint/Commerce/Transaction/TransactionEndpoint.php
+++ b/src/V2/Endpoint/Commerce/Transaction/TransactionEndpoint.php
@@ -2,19 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Commerce\Transaction;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class TransactionEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 
     /**
      * {@inheritdoc}
@@ -30,7 +23,7 @@ class TransactionEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return TypeEndpoint
      */
     public function current() {
-        return new TypeEndpoint( $this->getApi(), $this->apiKey, 'current' );
+        return new TypeEndpoint( $this->getParent(), 'current' );
     }
 
     /**
@@ -39,6 +32,6 @@ class TransactionEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return TypeEndpoint
      */
     public function history() {
-        return new TypeEndpoint( $this->getApi(), $this->apiKey, 'history' );
+        return new TypeEndpoint( $this->getParent(), 'history' );
     }
 }

--- a/src/V2/Endpoint/Commerce/Transaction/TypeEndpoint.php
+++ b/src/V2/Endpoint/Commerce/Transaction/TypeEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Commerce\Transaction;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use InvalidArgumentException;
 
 class TypeEndpoint extends Endpoint implements IAuthenticatedEndpoint {
@@ -16,17 +16,16 @@ class TypeEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     /** @var string $type */
     protected $type;
 
-    public function __construct( GW2Api $api, $apiKey, $type ) {
+    public function __construct( IParent $parent, $type ) {
         if( !in_array( $type, self::$types )) {
             throw new InvalidArgumentException(
-                'Invalid $type ("' . $type . '""), has to be one of: ' . implode(', ', self::$types)
+                'Invalid $type ("' . $type . '"), has to be one of: ' . implode(', ', self::$types)
             );
         }
 
         $this->type = $type;
-        $this->apiKey = $apiKey;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
 
@@ -44,7 +43,7 @@ class TypeEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return ListEndpoint
      */
     public function buys() {
-        return new ListEndpoint( $this->getApi(), $this->apiKey, $this->type, 'buys' );
+        return new ListEndpoint( $this->getParent(), $this->type, 'buys' );
     }
 
     /**
@@ -53,6 +52,6 @@ class TypeEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return ListEndpoint
      */
     public function sells() {
-        return new ListEndpoint( $this->getApi(), $this->apiKey, $this->type, 'sells' );
+        return new ListEndpoint( $this->getParent(), $this->type, 'sells' );
     }
 }

--- a/src/V2/Endpoint/Continent/ContinentEndpoint.php
+++ b/src/V2/Endpoint/Continent/ContinentEndpoint.php
@@ -25,6 +25,6 @@ class ContinentEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEnd
      * @return FloorEndpoint
      */
     public function floorsOf( $continent ) {
-        return new FloorEndpoint( $this->getApi(), $continent );
+        return new FloorEndpoint( $this->getParent(), $continent );
     }
 }

--- a/src/V2/Endpoint/Continent/FloorEndpoint.php
+++ b/src/V2/Endpoint/Continent/FloorEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Continent;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
@@ -16,13 +16,13 @@ class FloorEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoin
     protected $continent;
 
     /**
-     * @param GW2Api $api
-     * @param int    $continent
+     * @param IParent $parent
+     * @param int     $continent
      */
-    public function __construct( GW2Api $api, $continent ) {
+    public function __construct( IParent $parent, $continent ) {
         $this->continent = $continent;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**
@@ -40,6 +40,6 @@ class FloorEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoin
      * @return RegionEndpoint
      */
     public function regionsOf( $floor ) {
-        return new RegionEndpoint( $this->api, $this->continent, $floor );
+        return new RegionEndpoint( $this->parent, $this->continent, $floor );
     }
 }

--- a/src/V2/Endpoint/Continent/MapEndpoint.php
+++ b/src/V2/Endpoint/Continent/MapEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Continent;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
@@ -22,17 +22,17 @@ class MapEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint 
     protected $region;
 
     /**
-     * @param GW2Api $api
+     * @param IParent $parent
      * @param int    $continent
      * @param int    $floor
      * @param int    $region
      */
-    public function __construct( GW2Api $api, $continent, $floor, $region ) {
+    public function __construct( IParent $parent, $continent, $floor, $region ) {
         $this->continent = $continent;
         $this->floor = $floor;
         $this->region = $region;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**
@@ -50,7 +50,7 @@ class MapEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint 
      * @return PoiEndpoint
      */
     public function poisOf( $map ) {
-        return new PoiEndpoint( $this->api, $this->continent, $this->floor, $this->region, $map );
+        return new PoiEndpoint( $this->parent, $this->continent, $this->floor, $this->region, $map );
     }
 
     /**
@@ -61,7 +61,7 @@ class MapEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint 
      * @return TaskEndpoint
      */
     public function tasksOf( $map ) {
-        return new TaskEndpoint( $this->api, $this->continent, $this->floor, $this->region, $map );
+        return new TaskEndpoint( $this->parent, $this->continent, $this->floor, $this->region, $map );
     }
 
     /**
@@ -72,6 +72,6 @@ class MapEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint 
      * @return SectorEndpoint
      */
     public function sectorsOf( $map ) {
-        return new SectorEndpoint( $this->api, $this->continent, $this->floor, $this->region, $map );
+        return new SectorEndpoint( $this->parent, $this->continent, $this->floor, $this->region, $map );
     }
 }

--- a/src/V2/Endpoint/Continent/PoiEndpoint.php
+++ b/src/V2/Endpoint/Continent/PoiEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Continent;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
@@ -25,19 +25,19 @@ class PoiEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint 
     protected $map;
 
     /**
-     * @param GW2Api $api
-     * @param int    $continent
-     * @param int    $floor
-     * @param int    $region
-     * @param int    $map
+     * @param IParent $parent
+     * @param int     $continent
+     * @param int     $floor
+     * @param int     $region
+     * @param int     $map
      */
-    public function __construct( GW2Api $api, $continent, $floor, $region, $map ) {
+    public function __construct( IParent $parent, $continent, $floor, $region, $map ) {
         $this->continent_id = $continent;
         $this->floor = $floor;
         $this->region = $region;
         $this->map = $map;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**

--- a/src/V2/Endpoint/Continent/RegionEndpoint.php
+++ b/src/V2/Endpoint/Continent/RegionEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Continent;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
@@ -19,15 +19,15 @@ class RegionEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoi
     protected $floor;
 
     /**
-     * @param GW2Api $api
-     * @param int    $continent
-     * @param int    $floor
+     * @param IParent $parent
+     * @param int     $continent
+     * @param int     $floor
      */
-    public function __construct( GW2Api $api, $continent, $floor ) {
+    public function __construct( IParent $parent, $continent, $floor ) {
         $this->continent = $continent;
         $this->floor = $floor;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**
@@ -45,6 +45,6 @@ class RegionEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoi
      * @return MapEndpoint
      */
     public function mapsOf( $region ) {
-        return new MapEndpoint( $this->api, $this->continent, $this->floor, $region );
+        return new MapEndpoint( $this->parent, $this->continent, $this->floor, $region );
     }
 }

--- a/src/V2/Endpoint/Continent/SectorEndpoint.php
+++ b/src/V2/Endpoint/Continent/SectorEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Continent;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
@@ -25,19 +25,19 @@ class SectorEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoi
     protected $map;
 
     /**
-     * @param GW2Api $api
-     * @param int    $continent
-     * @param int    $floor
-     * @param int    $region
-     * @param int    $map
+     * @param IParent $parent
+     * @param int     $continent
+     * @param int     $floor
+     * @param int     $region
+     * @param int     $map
      */
-    public function __construct( GW2Api $api, $continent, $floor, $region, $map ) {
+    public function __construct( IParent $parent, $continent, $floor, $region, $map ) {
         $this->continent = $continent;
         $this->floor = $floor;
         $this->region = $region;
         $this->map = $map;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**

--- a/src/V2/Endpoint/Continent/TaskEndpoint.php
+++ b/src/V2/Endpoint/Continent/TaskEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Continent;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
 
@@ -25,19 +25,19 @@ class TaskEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint
     protected $map;
 
     /**
-     * @param GW2Api $api
-     * @param int    $continent
-     * @param int    $floor
-     * @param int    $region
-     * @param int    $map
+     * @param IParent $parent
+     * @param int     $continent
+     * @param int     $floor
+     * @param int     $region
+     * @param int     $map
      */
-    public function __construct( GW2Api $api, $continent, $floor, $region, $map ) {
+    public function __construct( IParent $parent, $continent, $floor, $region, $map ) {
         $this->continent = $continent;
         $this->floor = $floor;
         $this->region = $region;
         $this->map = $map;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 
     /**

--- a/src/V2/Endpoint/Emblem/EmblemEndpoint.php
+++ b/src/V2/Endpoint/Emblem/EmblemEndpoint.php
@@ -19,7 +19,7 @@ class EmblemEndpoint extends Endpoint {
      * @return LayerEndpoint
      */
     public function backgrounds() {
-        return new LayerEndpoint($this->api, LayerEndpoint::TYPE_BACKGROUNDS);
+        return new LayerEndpoint($this->parent, LayerEndpoint::TYPE_BACKGROUNDS);
     }
 
     /**
@@ -28,6 +28,6 @@ class EmblemEndpoint extends Endpoint {
      * @return LayerEndpoint
      */
     public function foregrounds() {
-        return new LayerEndpoint($this->api, LayerEndpoint::TYPE_FOREGROUNDS);
+        return new LayerEndpoint($this->parent, LayerEndpoint::TYPE_FOREGROUNDS);
     }
 }

--- a/src/V2/Endpoint/Emblem/LayerEndpoint.php
+++ b/src/V2/Endpoint/Emblem/LayerEndpoint.php
@@ -2,10 +2,10 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Emblem;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class LayerEndpoint extends Endpoint implements IBulkEndpoint {
     use BulkEndpoint;
@@ -25,11 +25,11 @@ class LayerEndpoint extends Endpoint implements IBulkEndpoint {
     protected $type;
 
     /**
-     * @param GW2Api $api
+     * @param IParent $parent
      * @param string $type Type of this endpoint.
      */
-    public function __construct(GW2Api $api, $type) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $type) {
+        parent::__construct($parent);
 
         if( !in_array($type, self::$types) ) {
             throw new \InvalidArgumentException('$type has to be one of '.implode(', ', self::$types));

--- a/src/V2/Endpoint/Guild/Authenticated/LogEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/LogEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class LogEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class LogEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestricte
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/Authenticated/MemberEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/MemberEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class MemberEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class MemberEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestri
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/Authenticated/RankEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/RankEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class RankEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class RankEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrict
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/Authenticated/StashEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/StashEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class StashEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class StashEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestric
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/Authenticated/TeamEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/TeamEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class TeamEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class TeamEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrict
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/Authenticated/TreasuryEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/TreasuryEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class TreasuryEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class TreasuryEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRest
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/Authenticated/UpgradeEndpoint.php
+++ b/src/V2/Endpoint/Guild/Authenticated/UpgradeEndpoint.php
@@ -2,11 +2,11 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Guild\Authenticated;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
+use GW2Treasures\GW2Api\V2\IParent;
 
 class UpgradeEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestrictedGuildEndpoint {
     use AuthenticatedEndpoint;
@@ -14,10 +14,9 @@ class UpgradeEndpoint extends Endpoint implements IAuthenticatedEndpoint, IRestr
     /** @var string $guildId */
     protected $guildId;
 
-    public function __construct(GW2Api $api, $apiKey, $guildId) {
-        parent::__construct($api);
+    public function __construct(IParent $parent, $guildId) {
+        parent::__construct($parent);
 
-        $this->apiKey = $apiKey;
         $this->guildId = $guildId;
     }
 

--- a/src/V2/Endpoint/Guild/GuildEndpoint.php
+++ b/src/V2/Endpoint/Guild/GuildEndpoint.php
@@ -24,23 +24,21 @@ class GuildEndpoint extends Endpoint {
     /**
      * Get log of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return LogEndpoint
      */
-    public function logOf($apiKey, $guildId) {
-        return new LogEndpoint($this->api, $apiKey, $guildId);
+    public function logOf($guildId) {
+        return new LogEndpoint($this->parent, $guildId);
     }
 
     /**
      * Get members of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return MemberEndpoint
      */
-    public function membersOf($apiKey, $guildId) {
-        return new MemberEndpoint($this->api, $apiKey, $guildId);
+    public function membersOf($guildId) {
+        return new MemberEndpoint($this->parent, $guildId);
     }
 
     /**
@@ -49,62 +47,57 @@ class GuildEndpoint extends Endpoint {
      * @return PermissionEndpoint
      */
     public function permissions() {
-        return new PermissionEndpoint($this->api);
+        return new PermissionEndpoint($this->parent);
     }
 
     /**
      * Get ranks of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return RankEndpoint
      */
-    public function ranksOf($apiKey, $guildId) {
-        return new RankEndpoint($this->api, $apiKey, $guildId);
+    public function ranksOf($guildId) {
+        return new RankEndpoint($this->parent, $guildId);
     }
 
     /**
      * Get stash of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return StashEndpoint
      */
-    public function stashOf($apiKey, $guildId) {
-        return new StashEndpoint($this->api, $apiKey, $guildId);
+    public function stashOf($guildId) {
+        return new StashEndpoint($this->parent, $guildId);
     }
 
     /**
      * Get teams of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return TeamEndpoint
      */
-    public function teamsOf($apiKey, $guildId) {
-        return new TeamEndpoint($this->api, $apiKey, $guildId);
+    public function teamsOf($guildId) {
+        return new TeamEndpoint($this->parent, $guildId);
     }
 
     /**
      * Get treasury of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return TreasuryEndpoint
      */
-    public function treasuryOf($apiKey, $guildId) {
-        return new TreasuryEndpoint($this->api, $apiKey, $guildId);
+    public function treasuryOf($guildId) {
+        return new TreasuryEndpoint($this->parent, $guildId);
     }
 
     /**
      * Get upgrades of a guild.
      *
-     * @param string $apiKey
      * @param string $guildId
      * @return AuthenticatedUpgradeEndpoint
      */
-    public function upgradesOf($apiKey, $guildId) {
-        return new AuthenticatedUpgradeEndpoint($this->api, $apiKey, $guildId);
+    public function upgradesOf($guildId) {
+        return new AuthenticatedUpgradeEndpoint($this->parent, $guildId);
     }
 
     /**
@@ -113,6 +106,6 @@ class GuildEndpoint extends Endpoint {
      * @return UpgradeEndpoint
      */
     public function upgrades() {
-        return new UpgradeEndpoint($this->api);
+        return new UpgradeEndpoint($this->parent);
     }
 }

--- a/src/V2/Endpoint/Pvp/GameEndpoint.php
+++ b/src/V2/Endpoint/Pvp/GameEndpoint.php
@@ -2,7 +2,6 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
@@ -11,16 +10,6 @@ use GW2Treasures\GW2Api\V2\Endpoint;
 
 class GameEndpoint extends Endpoint implements IAuthenticatedEndpoint, IBulkEndpoint {
     use AuthenticatedEndpoint, BulkEndpoint;
-
-    /**
-     * @param GW2Api $api
-     * @param string $apiKey
-     */
-    public function __construct(GW2Api $api, $apiKey) {
-        $this->apiKey = $apiKey;
-
-        parent::__construct($api);
-    }
 
     /**
      * The url of this endpoint.

--- a/src/V2/Endpoint/Pvp/PvpEndpoint.php
+++ b/src/V2/Endpoint/Pvp/PvpEndpoint.php
@@ -2,9 +2,6 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
 
-use GW2Treasures\GW2Api\GW2Api;
-use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
-use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class PvpEndpoint extends Endpoint {
@@ -21,37 +18,34 @@ class PvpEndpoint extends Endpoint {
      * @return AmuletEndpoint
      */
     public function amulets() {
-        return new AmuletEndpoint($this->api);
+        return new AmuletEndpoint($this->parent);
     }
 
     /**
-     * @param string $apiKey
      * @return GameEndpoint
      */
-    public function games($apiKey) {
-        return new GameEndpoint($this->api, $apiKey);
+    public function games() {
+        return new GameEndpoint($this->parent);
     }
 
     /**
      * @return SeasonEndpoint
      */
     public function seasons() {
-        return new SeasonEndpoint($this->api);
+        return new SeasonEndpoint($this->parent);
     }
 
     /**
-     * @param string $apiKey
      * @return StandingEndpoint
      */
-    public function standings($apiKey) {
-        return new StandingEndpoint($this->api, $apiKey);
+    public function standings() {
+        return new StandingEndpoint($this->parent);
     }
 
     /**
-     * @param string $apiKey
      * @return StatsEndpoint
      */
-    public function stats($apiKey) {
-        return new StatsEndpoint($this->api, $apiKey);
+    public function stats() {
+        return new StatsEndpoint($this->parent);
     }
 }

--- a/src/V2/Endpoint/Pvp/StandingEndpoint.php
+++ b/src/V2/Endpoint/Pvp/StandingEndpoint.php
@@ -2,25 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
-use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
-use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class StandingEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    /**
-     * @param GW2Api $api
-     * @param string $apiKey
-     */
-    public function __construct(GW2Api $api, $apiKey) {
-        $this->apiKey = $apiKey;
-
-        parent::__construct($api);
-    }
 
     /**
      * The url of this endpoint.

--- a/src/V2/Endpoint/Pvp/StatsEndpoint.php
+++ b/src/V2/Endpoint/Pvp/StatsEndpoint.php
@@ -2,23 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class StatsEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    /**
-     * @param GW2Api $api
-     * @param string $apiKey
-     */
-    public function __construct(GW2Api $api, $apiKey) {
-        $this->apiKey = $apiKey;
-
-        parent::__construct($api);
-    }
 
     /**
      * The url of this endpoint.

--- a/src/V2/Endpoint/Recipe/RecipeEndpoint.php
+++ b/src/V2/Endpoint/Recipe/RecipeEndpoint.php
@@ -23,6 +23,6 @@ class RecipeEndpoint extends Endpoint implements IBulkEndpoint {
      * @return SearchEndpoint
      */
     public function search() {
-        return new SearchEndpoint( $this->getApi() );
+        return new SearchEndpoint( $this->getParent() );
     }
 }

--- a/src/V2/Endpoint/Tokeninfo/TokeninfoEndpoint.php
+++ b/src/V2/Endpoint/Tokeninfo/TokeninfoEndpoint.php
@@ -2,20 +2,12 @@
 
 namespace GW2Treasures\GW2Api\V2\Endpoint\Tokeninfo;
 
-use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
 class TokeninfoEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
-
 
     /**
      * @inheritdoc

--- a/src/V2/Endpoint/WvW/WvWEndpoint.php
+++ b/src/V2/Endpoint/WvW/WvWEndpoint.php
@@ -13,10 +13,10 @@ class WvWEndpoint extends Endpoint {
     }
 
     public function matches() {
-        return new MatchEndpoint( $this->api );
+        return new MatchEndpoint( $this->parent );
     }
 
     public function objectives() {
-        return new ObjectiveEndpoint( $this->api );
+        return new ObjectiveEndpoint( $this->parent );
     }
 }

--- a/src/V2/EndpointTrait.php
+++ b/src/V2/EndpointTrait.php
@@ -3,12 +3,23 @@
 namespace GW2Treasures\GW2Api\V2;
 
 use GuzzleHttp\Client;
+use GW2Treasures\GW2Api\GW2Api;
 
 trait EndpointTrait {
     /**
      * @return Client
      */
     protected abstract function getClient();
+
+    /**
+     * @return GW2Api
+     */
+    protected abstract function getApi();
+
+    /**
+     * @return IParent
+     */
+    protected abstract function getParent();
 
     /**
      * Creates a new Request to this Endpoint.

--- a/src/V2/IParent.php
+++ b/src/V2/IParent.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace GW2Treasures\GW2Api\V2;
+
+
+interface IParent {
+    function getParent();
+
+    function getApi();
+}

--- a/tests/Stubs/AuthenticatedEndpointStub.php
+++ b/tests/Stubs/AuthenticatedEndpointStub.php
@@ -8,10 +8,4 @@ use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 
 class AuthenticatedEndpointStub extends EndpointStub implements IAuthenticatedEndpoint {
     use AuthenticatedEndpoint;
-
-    public function __construct( GW2Api $api, $apiKey ) {
-        parent::__construct( $api );
-
-        $this->apiKey = $apiKey;
-    }
 }

--- a/tests/Stubs/BulkEndpointStub.php
+++ b/tests/Stubs/BulkEndpointStub.php
@@ -9,10 +9,10 @@ use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 class BulkEndpointStub extends EndpointStub implements IBulkEndpoint {
     use BulkEndpoint;
 
-    public function __construct( GW2Api $api, $supportsIdsAll, $maxPageSize ) {
+    public function __construct( GW2Api $parent, $supportsIdsAll, $maxPageSize ) {
         $this->supportsIdsAll = $supportsIdsAll;
         $this->maxPageSize = $maxPageSize;
 
-        parent::__construct( $api );
+        parent::__construct( $parent );
     }
 }

--- a/tests/Stubs/PaginatedEndpointStub.php
+++ b/tests/Stubs/PaginatedEndpointStub.php
@@ -9,8 +9,8 @@ use GW2Treasures\GW2Api\V2\Pagination\PaginatedEndpoint;
 class PaginatedEndpointStub extends EndpointStub implements IPaginatedEndpoint {
     use PaginatedEndpoint;
 
-    public function __construct(  GW2Api $api, $maxPageSize = 10 ) {
-        parent::__construct( $api );
+    public function __construct(  GW2Api $parent, $maxPageSize = 10 ) {
+        parent::__construct( $parent );
 
         $this->maxPageSize = $maxPageSize;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,9 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
     /** @var array $history */
     protected $history = [];
 
+    /** @var string $apiKey */
+    protected $apiKey;
+
     /**
      * @return GW2Api
      */
@@ -35,6 +38,13 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
             $stack->push(Middleware::history($this->history));
 
             $this->api = new GW2Api(['handler' => $stack]);
+
+            if(!isset($this->apiKey)) {
+                $this->apiKey = 'API_KEY_'.rand(100, 999);
+            }
+
+            $this->api->auth($this->apiKey);
+
         }
         return $this->api;
     }
@@ -135,9 +145,15 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
         }
     }
 
-    public function assertEndpointIsAuthenticated( IEndpoint $endpoint ) {
+    public function assertEndpointIsAuthenticated( IEndpoint $endpoint, $apiKey = null ) {
         $this->assertInstanceOf( IAuthenticatedEndpoint::class, $endpoint );
-        $this->assertNotNull( $endpoint->getApiKey() );
+        /** @var IAuthenticatedEndpoint $endpoint */
+
+        if($apiKey === null) {
+            $apiKey = $this->apiKey;
+        }
+
+        $this->assertEquals( $apiKey, $endpoint->getApiKey() );
     }
 
     public function assertEndpointIsBulk( IEndpoint $endpoint ) {

--- a/tests/V2/CharacterEquipmentEndpointTest.php
+++ b/tests/V2/CharacterEquipmentEndpointTest.php
@@ -6,7 +6,7 @@ use TestCase;
 
 class CharacterEquipmentEndpointTest extends TestCase {
     public function test() {
-        $endpoint = $this->api()->characters('test')->equipmentOf('char');
+        $endpoint = $this->api()->characters()->equipmentOf('char');
 
         $this->assertEndpointIsAuthenticated( $endpoint );
         $this->assertEndpointUrl( 'v2/characters/char/equipment', $endpoint );
@@ -16,7 +16,7 @@ class CharacterEquipmentEndpointTest extends TestCase {
     }
 
     public function testCharacterNameEncoding() {
-        $endpoint = $this->api()->characters('test')->equipmentOf('Character Namè');
+        $endpoint = $this->api()->characters()->equipmentOf('Character Namè');
 
         $this->assertEndpointUrl( 'v2/characters/Character%20Nam%C3%A8/equipment', $endpoint );
     }

--- a/tests/V2/CommerceTransactionEndpointTest.php
+++ b/tests/V2/CommerceTransactionEndpointTest.php
@@ -5,7 +5,7 @@ use GW2Treasures\GW2Api\V2\Endpoint\Commerce\Transaction\TypeEndpoint;
 
 class CommerceTransactionEndpointTest extends TestCase {
     public function testTransactionUrls() {
-        $endpoint = $this->api()->commerce()->transactions('api_key');
+        $endpoint = $this->api()->commerce()->transactions();
 
         $this->assertEndpointUrl( 'v2/commerce/transactions', $endpoint );
         $this->assertEndpointUrl( 'v2/commerce/transactions/current', $endpoint->current() );
@@ -13,7 +13,7 @@ class CommerceTransactionEndpointTest extends TestCase {
     }
 
     public function testCurrentBuys() {
-        $endpoint = $this->api()->commerce()->transactions('api_key')->current()->buys();
+        $endpoint = $this->api()->commerce()->transactions()->current()->buys();
 
         $this->assertEndpointIsAuthenticated( $endpoint );
         $this->assertEndpointIsPaginated( $endpoint );
@@ -30,7 +30,7 @@ class CommerceTransactionEndpointTest extends TestCase {
     }
 
     public function testCurrentSells() {
-        $endpoint = $this->api()->commerce()->transactions('api_key')->current()->sells();
+        $endpoint = $this->api()->commerce()->transactions()->current()->sells();
 
         $this->assertEndpointIsAuthenticated( $endpoint );
         $this->assertEndpointIsPaginated( $endpoint );
@@ -47,7 +47,7 @@ class CommerceTransactionEndpointTest extends TestCase {
     }
 
     public function testHistoryBuys() {
-        $endpoint = $this->api()->commerce()->transactions('api_key')->history()->buys();
+        $endpoint = $this->api()->commerce()->transactions()->history()->buys();
 
         $this->assertEndpointIsAuthenticated( $endpoint );
         $this->assertEndpointIsPaginated( $endpoint );
@@ -65,7 +65,7 @@ class CommerceTransactionEndpointTest extends TestCase {
     }
 
     public function testHistorySells() {
-        $endpoint = $this->api()->commerce()->transactions('api_key')->history()->sells();
+        $endpoint = $this->api()->commerce()->transactions()->history()->sells();
 
         $this->assertEndpointIsAuthenticated( $endpoint );
         $this->assertEndpointIsPaginated( $endpoint );

--- a/tests/V2/GuildEndpointTest.php
+++ b/tests/V2/GuildEndpointTest.php
@@ -15,7 +15,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testLog() {
-        $endpoint = $this->api()->guild()->logOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->logOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/log', $endpoint);
         $this->assertEndpointIsAuthenticated($endpoint);
@@ -26,7 +26,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testMembers() {
-        $endpoint = $this->api()->guild()->membersOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->membersOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/members', $endpoint);
         $this->assertEndpointIsAuthenticated($endpoint);
@@ -48,7 +48,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testRanks() {
-        $endpoint = $this->api()->guild()->ranksOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->ranksOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/ranks', $endpoint);
         $this->assertEndpointIsAuthenticated($endpoint);
@@ -59,7 +59,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testStash() {
-        $endpoint = $this->api()->guild()->stashOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->stashOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/stash', $endpoint);
         $this->assertEndpointIsAuthenticated($endpoint);
@@ -70,7 +70,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testTeams() {
-        $endpoint = $this->api()->guild()->teamsOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->teamsOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/teams', $endpoint);
         $this->assertEndpointIsAuthenticated($endpoint);
@@ -81,7 +81,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testTreasury() {
-        $endpoint = $this->api()->guild()->treasuryOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->treasuryOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/treasury', $endpoint);
         $this->assertEndpointIsAuthenticated($endpoint);
@@ -103,7 +103,7 @@ class GuildEndpointTest extends TestCase {
     }
 
     public function testUpgradesOf() {
-        $endpoint = $this->api()->guild()->upgradesOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->upgradesOf('GUILD_ID');
 
         $this->assertEndpointUrl('v2/guild/GUILD_ID/upgrades', $endpoint);
         $this->assertEndpointIsAuthenticated( $endpoint );
@@ -116,7 +116,7 @@ class GuildEndpointTest extends TestCase {
     public function testMembershipRequiredException() {
         $this->setExpectedException(MembershipRequiredException::class);
 
-        $endpoint = $this->api()->guild()->ranksOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->ranksOf('GUILD_ID');
 
         $this->assertInstanceOf(IRestrictedGuildEndpoint::class, $endpoint);
 
@@ -131,7 +131,7 @@ class GuildEndpointTest extends TestCase {
     public function testGuildLeaderRequiredException() {
         $this->setExpectedException(GuildLeaderRequiredException::class);
 
-        $endpoint = $this->api()->guild()->ranksOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->ranksOf('GUILD_ID');
 
         $this->assertInstanceOf(IRestrictedGuildEndpoint::class, $endpoint);
 
@@ -149,7 +149,7 @@ class GuildEndpointTest extends TestCase {
     public function testOtherException() {
         $this->setExpectedException(ApiException::class);
 
-        $endpoint = $this->api()->guild()->membersOf('API_KEY', 'GUILD_ID');
+        $endpoint = $this->api()->guild()->membersOf('GUILD_ID');
 
         $this->assertInstanceOf(IRestrictedGuildEndpoint::class, $endpoint);
 


### PR DESCRIPTION
This PR removes the $apiKey from the specific endpoint implementation. Everything is handled by the AuthenticatedEndpoint trait now. The API key can be set in a parent endpoint and is inherited.

Examples:
```php
// old
$api->account('API_KEY')->achievements()->get();
// new
$api->account()->achievements()->auth('API_KEY')->get() // or
$api->auth('API_KEY')->account()->achievements()->get()

// old
$api->characters('API_KEY')->inventoryOf('Char Name')->get();
$api->characters('API_KEY')->equipmentOf('Char Name')->get();
$api->guild()->membersOf('API_KEY', 'GUILD_ID');
$api->pvp()->standings('DIFFERENT_API_KEY')->get();
// new
$api->auth('API_KEY');
$api->characters()->inventoryOf('Char Name')->get();
$api->characters()->equipmentOf('Char Name')->get();
$api->guild()->membersOf('GUILD_ID')->get();
$api->pvp()->standings()->auth('DIFFERENT_API_KEY')->get();
