### PR TITLE
Adds /v2/guild/:id endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For all examples it is assumed that you have a variable `$api = new GW2Api()`.
  ~~/v2/events~~               | *disabled*                                                                                         | 🌏🚫
  ~~/v2/events-state~~         | *disabled*                                                                                         | 🚫
  /v2/files                    | [File\FileEndpoint][FileEndpoint]                          <br>`GW2Api::files()`                   | 📦
- ~~/v2/guild/:id~~            | *disabled*                                                                                         | 🚫
+ /v2/guild/:id                | [Guild\DetailsEndpoint][Guild\DetailsEndpoint]             <br>`GW2Api::guild()->detailsOf()`      | 🔓                                                                                  | 🚫
  /v2/guild/:id/log            | [Guild\Authenticated\LogEndpoint][Guild\Authenticated\LogEndpoint] <br>`GW2Api::guild()->logOf()`  | 🔒
  /v2/guild/:id/members        | [Guild\Authenticated\MemberEndpoint][Guild\Authenticated\MemberEndpoint] <br>`GW2Api::guild()->membersOf()`     | 🔒
  /v2/guild/:id/ranks          | [Guild\Authenticated\RankEndpoint][Guild\Authenticated\RankEndpoint] <br>`GW2Api::guild()->ranksOf()`           | 🔒
@@ -1027,6 +1027,29 @@ Implements [📦BulkEndpoint][BulkEndpoint].
 $api->files()->ids();
 // => [ "map_complete", "map_dungeon", … ]
 ```
+
+
+#### /v2/guild/:id
+[Guild\DetailsEndpoint]: #v2guildid
+
+`\GW2Treasures\GW2Api\V2\Endpoint\Guild\DetailsEndpoint`
+([source](src/V2/Endpoint/Guild/DetailsEndpoint.php))
+
+Implements [🔒AuthenticatedEndpoint][AuthenticatedEndpoint]. The API key is optional.
+
+##### Methods
+ - Inherited methods from [🔒AuthenticatedEndpoint][AuthenticatedEndpoint]
+ - `get():array` Get the guild details of a guild.
+
+##### Example
+```php
+$api->guild()->detailsOf('GUILD_ID');
+// => { id: "GUILD_ID", name: "Test Guild", tag: "API", … }
+
+$api->guild()->detailsOf('GUILD_ID', 'API_KEY');
+// => { level: 42, motd: "gw2treasures.com\n", id: "GUILD_ID", name: "Test Guild", tag: "API", … }
+```
+
 
 #### /v2/guild/:id/log
 [Guild\Authenticated\LogEndpoint]: #v2guildidlog

--- a/src/V2/Authentication/AuthenticationHandler.php
+++ b/src/V2/Authentication/AuthenticationHandler.php
@@ -25,7 +25,13 @@ class AuthenticationHandler extends ApiHandler {
      * @return MessageInterface|RequestInterface
      */
     public function onRequest( RequestInterface $request ) {
-        return $request->withHeader( 'Authorization', 'Bearer ' . $this->getEndpoint()->getApiKey() );
+        $apiKey = $this->getEndpoint()->getApiKey();
+
+        if($apiKey !== null) {
+            $request = $request->withHeader( 'Authorization', 'Bearer '.$apiKey);
+        }
+
+        return $request;
     }
 
     /**

--- a/src/V2/Endpoint/Guild/DetailsEndpoint.php
+++ b/src/V2/Endpoint/Guild/DetailsEndpoint.php
@@ -1,23 +1,30 @@
 <?php
 
-namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
+namespace GW2Treasures\GW2Api\V2\Endpoint\Guild;
 
 use GW2Treasures\GW2Api\GW2Api;
 use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
-class StandingEndpoint extends Endpoint implements IAuthenticatedEndpoint {
-    use AuthenticatedEndpoint;
+class DetailsEndpoint extends Endpoint implements IAuthenticatedEndpoint {
+    use AuthenticatedEndpoint ;
+
+    /** @var string $guildId */
+    private $guildId;
 
     /**
+     * DetailsEndpoint constructor.
+     *
      * @param GW2Api $api
-     * @param string $apiKey
+     * @param $guildId
+     * @param null $apiKey
      */
-    public function __construct(GW2Api $api, $apiKey) {
-        $this->apiKey = $apiKey;
-
+    public function __construct(GW2Api $api, $guildId, $apiKey = null) {
         parent::__construct($api);
+
+        $this->guildId = $guildId;
+        $this->apiKey = $apiKey;
     }
 
     /**
@@ -26,11 +33,11 @@ class StandingEndpoint extends Endpoint implements IAuthenticatedEndpoint {
      * @return string
      */
     public function url() {
-        return 'v2/pvp/standings';
+        return 'v2/guild/'.$this->guildId;
     }
 
     /**
-     * Get your standing pvp info.
+     * Get the guild details.
      *
      * @return mixed
      */

--- a/src/V2/Endpoint/Guild/GuildEndpoint.php
+++ b/src/V2/Endpoint/Guild/GuildEndpoint.php
@@ -22,6 +22,17 @@ class GuildEndpoint extends Endpoint {
     }
 
     /**
+     * Get the guild details of a guild.
+     *
+     * @param string $guildId
+     * @param string|null $apiKey
+     * @return DetailsEndpoint
+     */
+    public function detailsOf($guildId, $apiKey = null) {
+        return new DetailsEndpoint($this->api, $guildId, $apiKey);
+    }
+
+    /**
      * Get log of a guild.
      *
      * @param string $apiKey

--- a/tests/AuthenticatedEndpointTest.php
+++ b/tests/AuthenticatedEndpointTest.php
@@ -68,4 +68,13 @@ class AuthenticatedEndpointTest extends TestCase {
 
         $this->getAuthenticatedEndpoint('invalid')->test();
     }
+
+    public function testNullKey() {
+        $this->mockResponse('[]');
+
+        $this->getAuthenticatedEndpoint(null)->test();
+
+        $request = $this->getLastRequest();
+        $this->assertHasNotHeader($request, 'Authorization');
+    }
 }

--- a/tests/V2/GuildEndpointTest.php
+++ b/tests/V2/GuildEndpointTest.php
@@ -3,6 +3,7 @@
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
 use GW2Treasures\GW2Api\Exception\ApiException;
+use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\Exception\GuildLeaderRequiredException;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\Exception\MembershipRequiredException;
 use GW2Treasures\GW2Api\V2\Endpoint\Guild\IRestrictedGuildEndpoint;
@@ -12,6 +13,27 @@ class GuildEndpointTest extends TestCase {
         $endpoint = $this->api()->guild();
 
         $this->assertEndpointUrl('v2/guild', $endpoint);
+    }
+
+    public function testDetails() {
+        $endpoint = $this->api()->guild()->detailsOf('GUILD_ID');
+
+        $this->assertEndpointUrl('v2/guild/GUILD_ID', $endpoint);
+        $this->assertInstanceOf(IAuthenticatedEndpoint::class, $endpoint);
+        $this->assertNull($endpoint->getApiKey());
+
+        $this->mockResponse('{"id":"GUILD_ID","name":"Test Guild","tag":"API"}');
+        $this->assertEquals('API', $endpoint->get()->tag);
+    }
+
+    public function testDetailsAuthenticated() {
+        $endpoint = $this->api()->guild()->detailsOf('GUILD_ID', 'API_KEY');
+
+        $this->assertEndpointUrl('v2/guild/GUILD_ID', $endpoint);
+        $this->assertEndpointIsAuthenticated($endpoint);
+
+        $this->mockResponse('{"level":42,"motd":"Test everything\n","id":"GUILD_ID","name":"Test Guild","tag":"API"}');
+        $this->assertEquals('API', $endpoint->get()->tag);
     }
 
     public function testLog() {


### PR DESCRIPTION
Adds */v2/guild/:id* endpoint. This also adds the ability to pass `null` as `$apiKey` to omit the header, because this endpoint can be requested with and without API key and returns different data. Closes #95.