### PR TITLE
Add currently missing endpoints

### DIFF
--- a/src/V2/Endpoint/Account/AccountEndpoint.php
+++ b/src/V2/Endpoint/Account/AccountEndpoint.php
@@ -105,6 +105,15 @@ class AccountEndpoint extends Endpoint implements IAuthenticatedEndpoint {
     }
 
     /**
+     * Get unlocked outfits.
+     *
+     * @return MiniEndpoint
+     */
+    public function outfits() {
+        return new OutfitEndpoint( $this->api, $this->apiKey );
+    }
+
+    /**
      * Get unlocked recipes.
      *
      * @return RecipeEndpoint

--- a/src/V2/Endpoint/Account/OutfitEndpoint.php
+++ b/src/V2/Endpoint/Account/OutfitEndpoint.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Endpoint\Account;
+
+use GW2Treasures\GW2Api\GW2Api;
+use GW2Treasures\GW2Api\V2\Authentication\AuthenticatedEndpoint;
+use GW2Treasures\GW2Api\V2\Authentication\IAuthenticatedEndpoint;
+use GW2Treasures\GW2Api\V2\Endpoint;
+
+class OutfitEndpoint extends Endpoint implements IAuthenticatedEndpoint {
+    use AuthenticatedEndpoint;
+
+    public function __construct( GW2Api $api, $apiKey ) {
+        parent::__construct( $api );
+
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function url() {
+        return 'v2/account/outfits';
+    }
+
+    public function get() {
+        return $this->request()->json();
+    }
+}

--- a/src/V2/Endpoint/Guild/GuildEndpoint.php
+++ b/src/V2/Endpoint/Guild/GuildEndpoint.php
@@ -75,6 +75,15 @@ class GuildEndpoint extends Endpoint {
     }
 
     /**
+     * Search for a guild.
+     *
+     * @return SearchEndpoint
+     */
+    public function search() {
+        return new SearchEndpoint($this->api);
+    }
+
+    /**
      * Get stash of a guild.
      *
      * @param string $apiKey

--- a/src/V2/Endpoint/Guild/SearchEndpoint.php
+++ b/src/V2/Endpoint/Guild/SearchEndpoint.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Endpoint\Guild;
+
+use GW2Treasures\GW2Api\V2\Endpoint;
+
+class SearchEndpoint extends Endpoint {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function url() {
+        return 'v2/guild/search';
+    }
+
+    /**
+     * @param int $name
+     * @return string[]
+     */
+    public function name( $name ) {
+        return $this->request([ 'name' => $name ])->json();
+    }
+}

--- a/src/V2/Endpoint/Pvp/LeaderboardEndpoint.php
+++ b/src/V2/Endpoint/Pvp/LeaderboardEndpoint.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
+
+use GW2Treasures\GW2Api\GW2Api;
+use GW2Treasures\GW2Api\V2\Endpoint;
+
+class LeaderboardEndpoint extends Endpoint {
+    /** @var string $season */
+    private $season;
+
+    /**
+     * @param GW2Api $api
+     * @param string $season
+     */
+    public function __construct(GW2Api $api, $season) {
+        parent::__construct($api);
+        $this->season = $season;
+    }
+
+    /**
+     * The url of this endpoint.
+     *
+     * @return string
+     */
+    public function url() {
+        return 'v2/pvp/seasons/'.$this->season.'/leaderboards';
+    }
+
+    /**
+     * Get a list of available leaderboards.
+     *
+     * @return string[]
+     */
+    public function ids() {
+        return $this->request()->json();
+    }
+
+    public function get($leaderboard, $region) {
+        return new LeaderboardRegionEndpoint($this->api, $this->season, $leaderboard, $region);
+    }
+}

--- a/src/V2/Endpoint/Pvp/LeaderboardRegionEndpoint.php
+++ b/src/V2/Endpoint/Pvp/LeaderboardRegionEndpoint.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
+
+use GW2Treasures\GW2Api\GW2Api;
+use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\Pagination\IPaginatedEndpoint;
+use GW2Treasures\GW2Api\V2\Pagination\PaginatedEndpoint;
+
+class LeaderboardRegionEndpoint extends Endpoint implements IPaginatedEndpoint {
+    use PaginatedEndpoint;
+
+    /** @var string $season */
+    private $season;
+
+    /** @var string $leaderboard */
+    private $leaderboard;
+
+    /** @var string $region */
+    private $region;
+
+    /**
+     * @param GW2Api $api
+     * @param string $season
+     * @param string $leaderboard
+     * @param string $region
+     */
+    public function __construct(GW2Api $api, $season, $leaderboard, $region) {
+        parent::__construct($api);
+
+        $this->season = $season;
+        $this->leaderboard = $leaderboard;
+        $this->region = $region;
+    }
+
+
+    /**
+     * The url of this endpoint.
+     *
+     * @return string
+     */
+    public function url() {
+        return 'v2/pvp/seasons/'.$this->season.'/leaderboards/'.$this->leaderboard.'/'.$this->region;
+    }
+}

--- a/src/V2/Endpoint/Pvp/PvpEndpoint.php
+++ b/src/V2/Endpoint/Pvp/PvpEndpoint.php
@@ -33,6 +33,13 @@ class PvpEndpoint extends Endpoint {
     }
 
     /**
+     * @return RankEndpoint
+     */
+    public function ranks() {
+        return new RankEndpoint($this->api);
+    }
+
+    /**
      * @return SeasonEndpoint
      */
     public function seasons() {

--- a/src/V2/Endpoint/Pvp/RankEndpoint.php
+++ b/src/V2/Endpoint/Pvp/RankEndpoint.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Endpoint\Pvp;
+
+use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
+use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
+use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
+use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
+
+class RankEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint {
+    use BulkEndpoint, LocalizedEndpoint;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function url() {
+        return 'v2/pvp/ranks';
+    }
+}

--- a/src/V2/Endpoint/Pvp/SeasonEndpoint.php
+++ b/src/V2/Endpoint/Pvp/SeasonEndpoint.php
@@ -17,4 +17,8 @@ class SeasonEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoi
     public function url() {
         return 'v2/pvp/seasons';
     }
+
+    public function leaderboardsOf($season) {
+        return new LeaderboardEndpoint($this->api, $season);
+    }
 }

--- a/src/V2/Endpoint/WvW/OverviewEndpoint.php
+++ b/src/V2/Endpoint/WvW/OverviewEndpoint.php
@@ -6,14 +6,14 @@ use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
-class MatchEndpoint extends Endpoint implements IBulkEndpoint {
+class OverviewEndpoint extends Endpoint implements IBulkEndpoint {
     use BulkEndpoint;
 
     /**
      * {@inheritdoc}
      */
     public function url() {
-        return 'v2/wvw/matches';
+        return 'v2/wvw/matches/overview';
     }
 
     /**
@@ -24,17 +24,5 @@ class MatchEndpoint extends Endpoint implements IBulkEndpoint {
      */
     public function world($id) {
         return $this->request(['world' => $id])->json();
-    }
-
-    public function overview() {
-        return new OverviewEndpoint($this->api);
-    }
-
-    public function scores() {
-        return new ScoreEndpoint($this->api);
-    }
-
-    public function stats() {
-        return new StatEndpoint($this->api);
     }
 }

--- a/src/V2/Endpoint/WvW/RankEndpoint.php
+++ b/src/V2/Endpoint/WvW/RankEndpoint.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Endpoint\WvW;
+
+use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
+use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
+use GW2Treasures\GW2Api\V2\Endpoint;
+use GW2Treasures\GW2Api\V2\Localization\ILocalizedEndpoint;
+use GW2Treasures\GW2Api\V2\Localization\LocalizedEndpoint;
+
+class RankEndpoint extends Endpoint implements IBulkEndpoint, ILocalizedEndpoint {
+    use BulkEndpoint, LocalizedEndpoint;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function url() {
+        return 'v2/wvw/ranks';
+    }
+}

--- a/src/V2/Endpoint/WvW/ScoreEndpoint.php
+++ b/src/V2/Endpoint/WvW/ScoreEndpoint.php
@@ -6,14 +6,14 @@ use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
-class MatchEndpoint extends Endpoint implements IBulkEndpoint {
+class ScoreEndpoint extends Endpoint implements IBulkEndpoint {
     use BulkEndpoint;
 
     /**
      * {@inheritdoc}
      */
     public function url() {
-        return 'v2/wvw/matches';
+        return 'v2/wvw/matches/scores';
     }
 
     /**
@@ -24,17 +24,5 @@ class MatchEndpoint extends Endpoint implements IBulkEndpoint {
      */
     public function world($id) {
         return $this->request(['world' => $id])->json();
-    }
-
-    public function overview() {
-        return new OverviewEndpoint($this->api);
-    }
-
-    public function scores() {
-        return new ScoreEndpoint($this->api);
-    }
-
-    public function stats() {
-        return new StatEndpoint($this->api);
     }
 }

--- a/src/V2/Endpoint/WvW/StatEndpoint.php
+++ b/src/V2/Endpoint/WvW/StatEndpoint.php
@@ -6,14 +6,14 @@ use GW2Treasures\GW2Api\V2\Bulk\BulkEndpoint;
 use GW2Treasures\GW2Api\V2\Bulk\IBulkEndpoint;
 use GW2Treasures\GW2Api\V2\Endpoint;
 
-class MatchEndpoint extends Endpoint implements IBulkEndpoint {
+class StatEndpoint extends Endpoint implements IBulkEndpoint {
     use BulkEndpoint;
 
     /**
      * {@inheritdoc}
      */
     public function url() {
-        return 'v2/wvw/matches';
+        return 'v2/wvw/matches/stats';
     }
 
     /**
@@ -24,17 +24,5 @@ class MatchEndpoint extends Endpoint implements IBulkEndpoint {
      */
     public function world($id) {
         return $this->request(['world' => $id])->json();
-    }
-
-    public function overview() {
-        return new OverviewEndpoint($this->api);
-    }
-
-    public function scores() {
-        return new ScoreEndpoint($this->api);
-    }
-
-    public function stats() {
-        return new StatEndpoint($this->api);
     }
 }

--- a/src/V2/Endpoint/WvW/WvWEndpoint.php
+++ b/src/V2/Endpoint/WvW/WvWEndpoint.php
@@ -23,4 +23,8 @@ class WvWEndpoint extends Endpoint {
     public function objectives() {
         return new ObjectiveEndpoint( $this->api );
     }
+
+    public function ranks() {
+        return new RankEndpoint( $this->api );
+    }
 }

--- a/tests/V2/AccountEndpointTest.php
+++ b/tests/V2/AccountEndpointTest.php
@@ -100,6 +100,16 @@ class AccountEndpointTest extends TestCase {
         $this->assertEquals([1,2,3,4,5,6], $endpoint->get());
     }
 
+    public function testOutfits() {
+        $endpoint = $this->api()->account('test')->outfits();
+
+        $this->assertEndpointIsAuthenticated( $endpoint );
+        $this->assertEndpointUrl( 'v2/account/outfits', $endpoint );
+
+        $this->mockResponse('[1,2,3]');
+        $this->assertEquals([1,2,3], $endpoint->get());
+    }
+
     public function testRecipes() {
         $endpoint = $this->api()->account('test')->recipes();
 

--- a/tests/V2/GuildEndpointTest.php
+++ b/tests/V2/GuildEndpointTest.php
@@ -80,6 +80,17 @@ class GuildEndpointTest extends TestCase {
         $this->assertEquals('Leader', $endpoint->get()[0]->id);
     }
 
+    public function testSearch() {
+        $endpoint = $this->api()->guild()->search();
+
+        $this->assertEndpointUrl('v2/guild/search', $endpoint);
+
+        $this->mockResponse('["335C4BB3-5CA3-E511-80D3-E4115BD7186D"]');
+        $this->assertEquals('335C4BB3-5CA3-E511-80D3-E4115BD7186D', $endpoint->name("API Test")[0]);
+
+        $this->assertEquals('name=API%20Test', $this->getLastRequest()->getUri()->getQuery());
+    }
+
     public function testStash() {
         $endpoint = $this->api()->guild()->stashOf('API_KEY', 'GUILD_ID');
 

--- a/tests/V2/PvpEndpointTest.php
+++ b/tests/V2/PvpEndpointTest.php
@@ -35,6 +35,17 @@ class PvpEndpointTest extends TestCase {
         $this->assertContains('4FDC931F-677F-4369-B20A-9FBB6A63B2B4', $endpoint->ids());
     }
 
+    public function testRanks() {
+        $endpoint = $this->api()->pvp()->ranks();
+
+        $this->assertEndpointUrl('v2/pvp/ranks', $endpoint);
+        $this->assertEndpointIsBulk($endpoint);
+        $this->assertEndpointIsLocalized($endpoint);
+
+        $this->mockResponse('[1,2,3,4,5,6,7,8,9]');
+        $this->assertEquals([1,2,3,4,5,6,7,8,9], $endpoint->ids());
+    }
+
     public function testSeasons() {
         $endpoint = $this->api()->pvp()->seasons();
 

--- a/tests/V2/PvpEndpointTest.php
+++ b/tests/V2/PvpEndpointTest.php
@@ -64,6 +64,26 @@ class PvpEndpointTest extends TestCase {
         $this->assertEquals('PvP League Season One', $endpoint->get("44B85826-B5ED-4890-8C77-82DDF9F2CF2B")->name);
     }
 
+    public function testSeasonLeaderboardsList() {
+        $endpoint = $this->api()->pvp()->seasons()->leaderboardsOf('44B85826-B5ED-4890-8C77-82DDF9F2CF2B');
+
+        $this->assertEndpointUrl('v2/pvp/seasons/44B85826-B5ED-4890-8C77-82DDF9F2CF2B/leaderboards', $endpoint);
+
+        $this->mockResponse('["legendary","guild"]');
+        $this->assertEquals('legendary', $endpoint->ids()[0]);
+    }
+
+    public function testSeasonLeaderboardsGet() {
+        $endpoint = $this->api()->pvp()->seasons()->leaderboardsOf('44B85826-B5ED-4890-8C77-82DDF9F2CF2B')
+            ->get('legendary', 'na');
+
+        $this->assertEndpointUrl('v2/pvp/seasons/44B85826-B5ED-4890-8C77-82DDF9F2CF2B/leaderboards/legendary/na', $endpoint);
+        $this->assertEndpointIsPaginated($endpoint);
+
+        $this->mockResponse('[{"name":"darthmaim.6017", "rank":1}]');
+        $this->assertEquals('darthmaim.6017', $endpoint->page(0, 1)[0]->name);
+    }
+
     public function testStanding() {
         $endpoint = $this->api()->pvp()->standings('API_KEY');
 

--- a/tests/V2/WvWEndpointTest.php
+++ b/tests/V2/WvWEndpointTest.php
@@ -38,4 +38,15 @@ class WvWEndpointTest extends TestCase {
         $this->mockResponse('{"id":"2-6","scores":{"red":169331,"blue":246780,"green":216241}}');
         $this->assertEquals(169331, $endpoint->world('id')->scores->red);
     }
+
+    public function testRankEndpoint() {
+        $endpoint = $this->api()->wvw()->ranks();
+
+        $this->assertEndpointUrl('v2/wvw/ranks', $endpoint);
+        $this->assertEndpointIsBulk($endpoint);
+        $this->assertEndpointIsLocalized($endpoint);
+
+        $this->mockResponse('{"id":1,"title":"Invader","min_rank":1}');
+        $this->assertEquals('Invader', $endpoint->get(1)->title);
+    }
 }

--- a/tests/V2/WvWEndpointTest.php
+++ b/tests/V2/WvWEndpointTest.php
@@ -39,6 +39,36 @@ class WvWEndpointTest extends TestCase {
         $this->assertEquals(169331, $endpoint->world('id')->scores->red);
     }
 
+    public function testMatchOverviewEndpoint() {
+        $endpoint = $this->api()->wvw()->matches()->overview();
+
+        $this->assertEndpointUrl('v2/wvw/matches/overview', $endpoint);
+        $this->assertEndpointIsBulk($endpoint);
+
+        $this->mockResponse('{"id":"1-1","worlds":{"red":1008,"blue":1019,"green":1005}}');
+        $this->assertEquals(1008, $endpoint->world(1008)->worlds->red);
+    }
+
+    public function testMatchScoreEndpoint() {
+        $endpoint = $this->api()->wvw()->matches()->scores();
+
+        $this->assertEndpointUrl('v2/wvw/matches/scores', $endpoint);
+        $this->assertEndpointIsBulk($endpoint);
+
+        $this->mockResponse('{"id":"1-1","scores":{"red":169331,"blue":246780,"green":216241}}');
+        $this->assertEquals(169331, $endpoint->world(1008)->scores->red);
+    }
+
+    public function testMatchStatEndpoint() {
+        $endpoint = $this->api()->wvw()->matches()->stats();
+
+        $this->assertEndpointUrl('v2/wvw/matches/stats', $endpoint);
+        $this->assertEndpointIsBulk($endpoint);
+
+        $this->mockResponse('{"id":"1-1","deaths":{"red":7276,"blue":5922,"green":5767}}');
+        $this->assertEquals(7276, $endpoint->world(1008)->deaths->red);
+    }
+
     public function testRankEndpoint() {
         $endpoint = $this->api()->wvw()->ranks();
 


### PR DESCRIPTION
I didn't keep up with all the new endpoints that got released over the past few months. This PR adds them all.

#### Adds missing endpoints:
 - /v2/account/outfits
 - /v2/guild/search
 - /v2/pvp/ranks
 - /v2/wvw/ranks
 - /v2/wvw/matches/{overview,scores,stats}
 - /v2/pvp/seasons/:id/leaderboards/:board/:region