### PR TITLE
Add schema version support

### DIFF
--- a/src/GW2Api.php
+++ b/src/GW2Api.php
@@ -53,8 +53,12 @@ use GW2Treasures\GW2Api\V2\Endpoint\WvW\WvWEndpoint;
 use GW2Treasures\GW2Api\V2\IEndpoint;
 use GW2Treasures\GW2Api\V2\Localization\LocalizationHandler;
 use GW2Treasures\GW2Api\V2\Pagination\PaginationHandler;
+use GW2Treasures\GW2Api\V2\Schema\SchemaHandler;
 
 class GW2Api {
+    /** @const string */
+    const DEFAULT_SCHEMA = '2019-03-20T00:00:00Z';
+
     /** @var string $apiUrl */
     protected $apiUrl = 'https://api.guildwars2.com/';
 
@@ -66,6 +70,9 @@ class GW2Api {
 
     /** @var array $handlers */
     protected $handlers = [];
+
+    /** @var string $schema */
+    protected $schema = self::DEFAULT_SCHEMA;
 
     function __construct( array $options = [] ) {
         $this->options = $this->getOptions( $options );
@@ -149,6 +156,7 @@ class GW2Api {
         $this->registerHandler(LocalizationHandler::class);
         $this->registerHandler(PaginationHandler::class);
         $this->registerHandler(RestrictedGuildHandler::class);
+        $this->registerHandler(SchemaHandler::class);
     }
 
     public function getClient() {
@@ -329,5 +337,26 @@ class GW2Api {
                 $endpoint->attach( new $handler( $endpoint ) );
             }
         }
+    }
+
+    /**
+     * Set the schema version to use for this api instance.
+     *
+     * @param string $schema
+     * @return $this
+     */
+    public function schema( $schema ) {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Get the schema version used by this api instance.
+     *
+     * @return String
+     */
+    public function getSchema() {
+        return $this->schema;
     }
 }

--- a/src/V2/Endpoint.php
+++ b/src/V2/Endpoint.php
@@ -20,6 +20,9 @@ abstract class Endpoint implements IEndpoint {
     /** @var ApiHandler[] */
     protected $handlers = [];
 
+    /** @var string schema */
+    protected $schema = null;
+
     /**
      * @param GW2Api $api
      */
@@ -41,6 +44,28 @@ abstract class Endpoint implements IEndpoint {
      */
     protected function getApi() {
         return $this->api;
+    }
+
+    /**
+     * Set the schema version to use when requesting this endpoint.
+     *
+     * @param string $schema
+     * @return $this
+     */
+    public function schema( $schema ) {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Get the schema used to request this endpoint.
+     * Falls back to the global schema set in the GW2API instance.
+     *
+     * @return String
+     */
+    public function getSchema() {
+        return $this->schema !== null ? $this->schema : $this->getApi()->getSchema();
     }
 
     /**

--- a/src/V2/IEndpoint.php
+++ b/src/V2/IEndpoint.php
@@ -16,4 +16,20 @@ interface IEndpoint {
      * @return string
      */
     public function url();
+
+    /**
+     * Set the schema version to use when requesting this endpoint.
+     *
+     * @param string $schema
+     * @return $this
+     */
+    public function schema( $schema );
+
+    /**
+     * Get the schema used to request this endpoint.
+     * Falls back to the global schema set in the GW2API instance.
+     *
+     * @return String
+     */
+    public function getSchema();
 }

--- a/src/V2/Schema/SchemaHandler.php
+++ b/src/V2/Schema/SchemaHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GW2Treasures\GW2Api\V2\Schema;
+
+use GW2Treasures\GW2Api\V2\ApiHandler;
+use GW2Treasures\GW2Api\V2\IEndpoint;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\RequestInterface;
+
+class SchemaHandler extends ApiHandler {
+    function __construct( IEndpoint $endpoint ) {
+        parent::__construct( $endpoint );
+    }
+
+    /**
+     * Add the schema version header.
+     *
+     * @param RequestInterface $request
+     *
+     * @return MessageInterface|RequestInterface
+     */
+    public function onRequest( RequestInterface $request ) {
+        $schema = $this->getEndpoint()->getSchema();
+
+        return $request->withHeader( 'X-Schema-Version', $schema );
+    }
+}

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use GW2Treasures\GW2Api\GW2Api;
+use Stubs\EndpointStub;
+
+const EXPECTED_DEFAULT_SCHEMA = GW2Api::DEFAULT_SCHEMA;
+const EXPECTED_CUSTOM_SCHEMA = '2077-01-01T00:00:00Z';
+
+class SchemaTest extends TestCase {
+    protected function getEndpoint() {
+        return new EndpointStub( $this->api() );
+    }
+
+    public function testDefaultSchema() {
+        $this->mockResponse('[]');
+
+        $endpoint = $this->getEndpoint();
+
+        $this->assertEquals(EXPECTED_DEFAULT_SCHEMA, $endpoint->getSchema());
+
+        $endpoint->test();
+
+        $request = $this->getLastRequest();
+        $this->assertHasHeader($request, 'X-Schema-Version', EXPECTED_DEFAULT_SCHEMA);
+    }
+
+    public function testCustomSchema() {
+        $this->mockResponse('[]');
+
+        $endpoint = $this->getEndpoint()->schema(EXPECTED_CUSTOM_SCHEMA);
+
+        $this->assertEquals(EXPECTED_CUSTOM_SCHEMA, $endpoint->getSchema());
+
+        $endpoint->test();
+
+        $request = $this->getLastRequest();
+        $this->assertHasHeader($request, 'X-Schema-Version', EXPECTED_CUSTOM_SCHEMA);
+    }
+
+    public function testGlobalSchema() {
+        $this->mockResponse('[]');
+
+        $endpoint = $this->getEndpoint();
+        $this->assertEquals(EXPECTED_DEFAULT_SCHEMA, $endpoint->getSchema());
+
+        $this->api()->schema(EXPECTED_CUSTOM_SCHEMA);
+
+        $this->assertEquals(EXPECTED_CUSTOM_SCHEMA, $endpoint->getSchema());
+
+        $endpoint->test();
+
+        $request = $this->getLastRequest();
+        $this->assertHasHeader($request, 'X-Schema-Version', EXPECTED_CUSTOM_SCHEMA);
+
+        // clean up schema for other tests
+        $this->resetApi();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,6 +39,10 @@ abstract class TestCase extends PHPUnit_Framework_TestCase {
         return $this->api;
     }
 
+    protected function resetApi() {
+        unset($this->api);
+    }
+
     /**
      * @param Response|RequestException|string $response
      * @param string $language


### PR DESCRIPTION
Adds support for the new `X-Schema-Version` header.

```php
// uses the default schema (2019-03-20T00:00:00Z)
$api->items()->get(); 

// uses a custom global schema
$api->schema('2077-01-01T00:00:00Z');
$api->items()->get();

// uses a custom schema just for this endpoint
$api->items()->schema('2019-12-24T00:00:00Z')->get(); 
```