### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: php
+dist: trusty
 
 php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - if [[ $setup = 'phar' ]]; then travis_retry composer install --no-interaction --prefer-source; fi
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - if [[ $setup = 'phar' ]]; then php build/build.php; fi
 
 script:


### PR DESCRIPTION
Change linux distribution that is used to run the build on travis to trusty, since PHP 5.5 is not supported on newer images. Also disable XDebug to gain some performance and fix a Segfault happening on `setup=lowest`.