### PR TITLE
Improve code coverage for exception handling

### DIFF
--- a/src/V2/Endpoint.php
+++ b/src/V2/Endpoint.php
@@ -77,6 +77,7 @@ abstract class Endpoint implements IEndpoint {
      * @param string   $method
      * @param array    $options
      * @return ApiResponse
+     * @throws ApiException|GuzzleException
      */
     protected function request( array $query = [], $url = null, $method = 'GET', $options = [] ) {
         $request = $this->createRequest( $query, $url, $method, $options );

--- a/tests/ApiExceptionTest.php
+++ b/tests/ApiExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
@@ -62,10 +62,10 @@ class ApiExceptionTest extends BasicTestCase {
     /**
      */
     public function testRequestExceptionWithoutResponse() {
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class, 'RequestExceptionWithoutResponse');
+        $this->expectException(RequestException::class, 'RequestExceptionWithoutResponse');
 
         $this->mockResponse(
-            new ConnectException('RequestExceptionWithoutResponse', new Request('GET', 'test/exception'))
+            new RequestException('RequestExceptionWithoutResponse', new Request('GET', 'test/exception'))
         );
 
         $this->getEndpoint()->test();
@@ -75,14 +75,14 @@ class ApiExceptionTest extends BasicTestCase {
     /**
      */
     public function testRequestManyExceptionWithoutResponse() {
-        $this->expectException(\GuzzleHttp\Exception\ConnectException::class, 'RequestManyExceptionWithoutResponse');
+        $this->expectException(RequestException::class, 'RequestManyExceptionWithoutResponse');
 
         $this->mockResponse( new Response(
             200, [ 'X-Result-Total' => 10, 'Content-Type' => 'application/json; charset=utf-8' ],
             Utils::streamFor( '[1,2,3]' )
         ));
         $this->mockResponse(
-            new ConnectException('RequestManyExceptionWithoutResponse', new Request('GET', 'test/exception'))
+            new RequestException('RequestManyExceptionWithoutResponse', new Request('GET', 'test/exception'))
         );
 
         $this->getEndpoint()->testMany(2);


### PR DESCRIPTION
In the new guzzle version ConnectException does not extend RequestException anymore, so our testcase was not testing the path it was supposed to.